### PR TITLE
Issue #2: OPA assessments extract, prepare, load pipeline

### DIFF
--- a/tasks/data-pipeline/workflow.yaml
+++ b/tasks/data-pipeline/workflow.yaml
@@ -5,39 +5,97 @@ main:
           - extract_url: "REPLACE_WITH_EXTRACT_URL"
           - prepare_url: "REPLACE_WITH_PREPARE_URL"
           - load_url: "REPLACE_WITH_LOAD_URL"
+          - assessments_extract_url: "REPLACE_WITH_ASSESSMENTS_EXTRACT_URL"
+          - assessments_prepare_url: "REPLACE_WITH_ASSESSMENTS_PREPARE_URL"
+          - assessments_load_url: "REPLACE_WITH_ASSESSMENTS_LOAD_URL"
+          - extract_result: null
+          - prepare_result: null
+          - load_result: null
+          - assessments_extract_result: null
+          - assessments_prepare_result: null
+          - assessments_load_result: null
 
-    - extract:
-        call: http.post
-        args:
-          url: ${extract_url}
-          auth:
-            type: OIDC
-          timeout: 1800
-          body: {}
-        result: extract_result
+    - run_pipelines:
+        parallel:
+          shared:
+            - extract_result
+            - prepare_result
+            - load_result
+            - assessments_extract_result
+            - assessments_prepare_result
+            - assessments_load_result
+          branches:
+            - opa_properties:
+                steps:
+                  - extract:
+                      call: http.post
+                      args:
+                        url: ${extract_url}
+                        auth:
+                          type: OIDC
+                        timeout: 1800
+                        body: {}
+                      result: extract_result
 
-    - prepare:
-        call: http.post
-        args:
-          url: ${prepare_url}
-          auth:
-            type: OIDC
-          timeout: 1800
-          body: {}
-        result: prepare_result
+                  - prepare:
+                      call: http.post
+                      args:
+                        url: ${prepare_url}
+                        auth:
+                          type: OIDC
+                        timeout: 1800
+                        body: {}
+                      result: prepare_result
 
-    - load:
-        call: http.post
-        args:
-          url: ${load_url}
-          auth:
-            type: OIDC
-          timeout: 1800
-          body: {}
-        result: load_result
+                  - load:
+                      call: http.post
+                      args:
+                        url: ${load_url}
+                        auth:
+                          type: OIDC
+                        timeout: 1800
+                        body: {}
+                      result: load_result
+
+            - opa_assessments:
+                steps:
+                  - assessments_extract:
+                      call: http.post
+                      args:
+                        url: ${assessments_extract_url}
+                        auth:
+                          type: OIDC
+                        timeout: 1800
+                        body: {}
+                      result: assessments_extract_result
+
+                  - assessments_prepare:
+                      call: http.post
+                      args:
+                        url: ${assessments_prepare_url}
+                        auth:
+                          type: OIDC
+                        timeout: 1800
+                        body: {}
+                      result: assessments_prepare_result
+
+                  - assessments_load:
+                      call: http.post
+                      args:
+                        url: ${assessments_load_url}
+                        auth:
+                          type: OIDC
+                        timeout: 1800
+                        body: {}
+                      result: assessments_load_result
 
     - done:
         return:
-          extract: ${extract_result.body}
-          prepare: ${prepare_result.body}
-          load: ${load_result.body}
+          properties:
+            extract: ${extract_result.body}
+            prepare: ${prepare_result.body}
+            load: ${load_result.body}
+          assessments:
+            extract: ${assessments_extract_result.body}
+            prepare: ${assessments_prepare_result.body}
+            load: ${assessments_load_result.body}

--- a/tasks/opa-assessments/extract-opa-assessments/main.py
+++ b/tasks/opa-assessments/extract-opa-assessments/main.py
@@ -1,0 +1,76 @@
+import json
+import os
+import tempfile
+from pathlib import Path
+
+import functions_framework
+import requests
+from dotenv import load_dotenv
+from google.cloud import storage
+
+load_dotenv()
+
+
+DEFAULT_SOURCE_URL = "https://opendata-downloads.s3.amazonaws.com/assessments.csv"
+RAW_OBJECT_NAME = "opa_assessments/assessments.csv"
+
+
+@functions_framework.http
+def extract_opa_assessments(request):
+
+    raw_bucket = os.getenv("RAW_BUCKET")
+    if not raw_bucket:
+        return (
+            json.dumps({"ok": False, "error": "Missing RAW_BUCKET"}),
+            500,
+            {"Content-Type": "application/json"},
+        )
+
+    source_url = os.getenv("OPA_ASSESSMENTS_URL", DEFAULT_SOURCE_URL)
+
+    temp_dir = Path(tempfile.mkdtemp(dir="/tmp"))
+    local_csv = temp_dir / "assessments.csv"
+
+    try:
+        response = requests.get(source_url, stream=True, timeout=300)
+        response.raise_for_status()
+
+        with local_csv.open("wb") as f:
+            for chunk in response.iter_content(chunk_size=1024 * 1024):
+                if chunk:
+                    f.write(chunk)
+
+        storage_client = storage.Client()
+        bucket = storage_client.bucket(raw_bucket)
+        blob = bucket.blob(RAW_OBJECT_NAME)
+        blob.upload_from_filename(
+            str(local_csv),
+            content_type="text/csv",
+            timeout=600,
+        )
+
+        return (
+            json.dumps(
+                {
+                    "ok": True,
+                    "raw_uri": f"gs://{raw_bucket}/{RAW_OBJECT_NAME}",
+                }
+            ),
+            200,
+            {"Content-Type": "application/json"},
+        )
+
+    except Exception as e:
+        return (
+            json.dumps({"ok": False, "error": str(e)}),
+            500,
+            {"Content-Type": "application/json"},
+        )
+
+    finally:
+        try:
+            if local_csv.exists():
+                local_csv.unlink()
+            temp_dir.rmdir()
+        except Exception:
+            pass

--- a/tasks/opa-assessments/extract-opa-assessments/requirements.txt
+++ b/tasks/opa-assessments/extract-opa-assessments/requirements.txt
@@ -1,0 +1,4 @@
+functions-framework==3.*
+google-cloud-storage
+requests
+python-dotenv

--- a/tasks/opa-assessments/load-opa-assessments/main.py
+++ b/tasks/opa-assessments/load-opa-assessments/main.py
@@ -1,0 +1,97 @@
+import json
+import os
+from pathlib import Path
+
+import functions_framework
+from dotenv import load_dotenv
+from google.cloud import bigquery
+
+load_dotenv()
+
+
+SQL_DIR = Path(__file__).resolve().parent / "sql"
+
+
+def read_sql(filename, replacements):
+    sql = (SQL_DIR / filename).read_text()
+
+    for key, value in replacements.items():
+        sql = sql.replace(f"__{key}__", value)
+
+    return sql
+
+
+@functions_framework.http
+def load_opa_assessments(request):
+    del request
+
+    project_id = os.getenv("PROJECT_ID")
+    prepared_bucket = os.getenv("PREPARED_BUCKET")
+    source_dataset = os.getenv("BQ_SOURCE_DATASET")
+    core_dataset = os.getenv("BQ_CORE_DATASET")
+
+    if not project_id:
+        return (
+            json.dumps({"ok": False, "error": "Missing PROJECT_ID"}),
+            500,
+            {"Content-Type": "application/json"},
+        )
+
+    if not prepared_bucket:
+        return (
+            json.dumps({"ok": False, "error": "Missing PREPARED_BUCKET"}),
+            500,
+            {"Content-Type": "application/json"},
+        )
+
+    if not source_dataset:
+        return (
+            json.dumps({"ok": False, "error": "Missing BQ_SOURCE_DATASET"}),
+            500,
+            {"Content-Type": "application/json"},
+        )
+
+    if not core_dataset:
+        return (
+            json.dumps({"ok": False, "error": "Missing BQ_CORE_DATASET"}),
+            500,
+            {"Content-Type": "application/json"},
+        )
+
+    replacements = {
+        "PROJECT_ID": project_id,
+        "PREPARED_BUCKET": prepared_bucket,
+        "BQ_SOURCE_DATASET": source_dataset,
+        "BQ_CORE_DATASET": core_dataset,
+    }
+
+    try:
+        client = bigquery.Client(project=project_id)
+
+        source_sql = read_sql("source_opa_assessments.sql", replacements)
+        core_sql = read_sql("core_opa_assessments.sql", replacements)
+
+        print("running source sql", flush=True)
+        client.query(source_sql).result()
+
+        print("running core sql", flush=True)
+        client.query(core_sql).result()
+
+        return (
+            json.dumps(
+                {
+                    "ok": True,
+                    "source_table": f"{project_id}.{source_dataset}.opa_assessments",
+                    "core_table": f"{project_id}.{core_dataset}.opa_assessments",
+                }
+            ),
+            200,
+            {"Content-Type": "application/json"},
+        )
+
+    except Exception as e:
+        return (
+            json.dumps({"ok": False, "error": str(e)}),
+            500,
+            {"Content-Type": "application/json"},
+        )

--- a/tasks/opa-assessments/load-opa-assessments/requirements.txt
+++ b/tasks/opa-assessments/load-opa-assessments/requirements.txt
@@ -1,0 +1,3 @@
+functions-framework==3.*
+google-cloud-bigquery
+python-dotenv

--- a/tasks/opa-assessments/load-opa-assessments/sql/core_opa_assessments.sql
+++ b/tasks/opa-assessments/load-opa-assessments/sql/core_opa_assessments.sql
@@ -1,0 +1,5 @@
+CREATE OR REPLACE TABLE `__PROJECT_ID__.__BQ_CORE_DATASET__.opa_assessments` AS
+SELECT
+    parcel_number AS property_id,
+    *
+FROM `__PROJECT_ID__.__BQ_SOURCE_DATASET__.opa_assessments`;

--- a/tasks/opa-assessments/load-opa-assessments/sql/source_opa_assessments.sql
+++ b/tasks/opa-assessments/load-opa-assessments/sql/source_opa_assessments.sql
@@ -1,0 +1,15 @@
+CREATE OR REPLACE EXTERNAL TABLE `__PROJECT_ID__.__BQ_SOURCE_DATASET__.opa_assessments`
+(
+    parcel_number STRING,
+    year STRING,
+    market_value STRING,
+    taxable_land STRING,
+    taxable_building STRING,
+    exempt_land STRING,
+    exempt_building STRING,
+    objectid STRING
+)
+OPTIONS (
+    format = 'JSON',
+    uris = ['gs://__PREPARED_BUCKET__/opa_assessments/data.jsonl']
+);

--- a/tasks/opa-assessments/prepare-opa-assessments/main.py
+++ b/tasks/opa-assessments/prepare-opa-assessments/main.py
@@ -1,0 +1,97 @@
+import csv
+import json
+import os
+import tempfile
+from pathlib import Path
+
+import functions_framework
+from dotenv import load_dotenv
+from google.cloud import storage
+
+load_dotenv()
+
+
+RAW_OBJECT_NAME = "opa_assessments/assessments.csv"
+PREPARED_OBJECT_NAME = "opa_assessments/data.jsonl"
+
+
+@functions_framework.http
+def prepare_opa_assessments(request):
+    del request
+
+    raw_bucket = os.getenv("RAW_BUCKET")
+    if not raw_bucket:
+        return (
+            json.dumps({"ok": False, "error": "Missing RAW_BUCKET"}),
+            500,
+            {"Content-Type": "application/json"},
+        )
+
+    prepared_bucket = os.getenv("PREPARED_BUCKET")
+    if not prepared_bucket:
+        return (
+            json.dumps({"ok": False, "error": "Missing PREPARED_BUCKET"}),
+            500,
+            {"Content-Type": "application/json"},
+        )
+
+    temp_dir = Path(tempfile.mkdtemp(dir="/tmp"))
+    local_csv = temp_dir / "assessments.csv"
+    local_jsonl = temp_dir / "data.jsonl"
+
+    try:
+        storage_client = storage.Client()
+
+        raw_blob = storage_client.bucket(raw_bucket).blob(RAW_OBJECT_NAME)
+        raw_blob.download_to_filename(str(local_csv))
+
+        row_count = 0
+
+        with local_csv.open("r", encoding="utf-8-sig", newline="") as f_in, \
+             local_jsonl.open("w", encoding="utf-8") as f_out:
+
+            reader = csv.DictReader(f_in)
+
+            for row in reader:
+                cleaned = {}
+                for key, value in row.items():
+                    cleaned[(key or "").strip().lower()] = value
+
+                f_out.write(json.dumps(cleaned, ensure_ascii=False) + "\n")
+                row_count += 1
+
+        prepared_blob = storage_client.bucket(prepared_bucket).blob(PREPARED_OBJECT_NAME)
+        prepared_blob.upload_from_filename(
+            str(local_jsonl),
+            content_type="application/x-ndjson",
+            timeout=600,
+        )
+
+        return (
+            json.dumps(
+                {
+                    "ok": True,
+                    "rows": row_count,
+                    "prepared_uri": f"gs://{prepared_bucket}/{PREPARED_OBJECT_NAME}",
+                }
+            ),
+            200,
+            {"Content-Type": "application/json"},
+        )
+
+    except Exception as e:
+        return (
+            json.dumps({"ok": False, "error": str(e)}),
+            500,
+            {"Content-Type": "application/json"},
+        )
+
+    finally:
+        try:
+            if local_csv.exists():
+                local_csv.unlink()
+            if local_jsonl.exists():
+                local_jsonl.unlink()
+            temp_dir.rmdir()
+        except Exception:
+            pass

--- a/tasks/opa-assessments/prepare-opa-assessments/requirements.txt
+++ b/tasks/opa-assessments/prepare-opa-assessments/requirements.txt
@@ -1,0 +1,3 @@
+functions-framework==3.*
+google-cloud-storage
+python-dotenv


### PR DESCRIPTION
This PR implements Issue #2 for the OPA assessment history pipeline.

What’s included:
- extract-opa-assessments function
- prepare-opa-assessments function
- load-opa-assessments function
- updates to the data-pipeline workflow

Details:
- extract downloads the OPA assessment history CSV and uploads it to the raw bucket
- prepare reads the raw CSV, converts it to lower-case JSONL, and uploads it to the prepared bucket
- load creates source.opa_assessments as an external table and core.opa_assessments as a BigQuery table
- property_id is set to parcel_number in core.opa_assessments
- workflow.yaml is extended so that OPA properties and OPA assessments run as parallel branches

Testing:
- extract tested successfully with functions-framework + curl
- prepare tested successfully and confirmed output in prepared bucket
- load tested successfully and confirmed source/core BigQuery tables