### PR TITLE
Add tax_year_assessment_bins SQL (Issue #7)

### DIFF
--- a/tasks/transform-tax-year-assessment-bins/sql/create_tax_year_assessment_bins.sql
+++ b/tasks/transform-tax-year-assessment-bins/sql/create_tax_year_assessment_bins.sql
@@ -6,7 +6,8 @@ WITH cleaned AS (
         CAST(market_value AS NUMERIC) AS assessed_value,
         parcel_number
     FROM `musa5090s26-team1.source.opa_assessments`
-    WHERE market_value IS NOT NULL
+    WHERE
+        market_value IS NOT NULL
         AND year IS NOT NULL
 ),
 
@@ -17,7 +18,8 @@ binned AS (
         CAST(FLOOR(assessed_value / 10000) * 10000 AS INT64) AS lower_bound,
         CAST(FLOOR(assessed_value / 10000) * 10000 + 10000 AS INT64) AS upper_bound
     FROM cleaned
-    WHERE assessed_value >= 0
+    WHERE
+        assessed_value >= 0
         AND tax_year >= 2015
 )
 

--- a/tasks/transform-tax-year-assessment-bins/sql/create_tax_year_assessment_bins.sql
+++ b/tasks/transform-tax-year-assessment-bins/sql/create_tax_year_assessment_bins.sql
@@ -1,34 +1,36 @@
 CREATE OR REPLACE TABLE `musa5090s26-team1.derived.tax_year_assessment_bins` AS
 
--- Step 1: Clean and cast raw data
 WITH cleaned AS (
-  SELECT
-    CAST(year AS INT64) AS tax_year,
-    CAST(market_value AS NUMERIC) AS assessed_value,
-    parcel_number
-  FROM `musa5090s26-team1.source.opa_assessments`
-  WHERE market_value IS NOT NULL
-    AND year IS NOT NULL
+    SELECT
+        CAST(year AS INT64) AS tax_year,
+        CAST(market_value AS NUMERIC) AS assessed_value,
+        parcel_number
+    FROM `musa5090s26-team1.source.opa_assessments`
+    WHERE market_value IS NOT NULL
+        AND year IS NOT NULL
 ),
 
--- Step 2: Create value bins
 binned AS (
-  SELECT
-    tax_year,
-    parcel_number,
-    CAST(FLOOR(assessed_value / 10000) * 10000 AS INT64) AS lower_bound,
-    CAST(FLOOR(assessed_value / 10000) * 10000 + 10000 AS INT64) AS upper_bound
-  FROM cleaned
-  WHERE assessed_value >= 0
-    AND tax_year >= 2015  -- remove incomplete years
+    SELECT
+        tax_year,
+        parcel_number,
+        CAST(FLOOR(assessed_value / 10000) * 10000 AS INT64) AS lower_bound,
+        CAST(FLOOR(assessed_value / 10000) * 10000 + 10000 AS INT64) AS upper_bound
+    FROM cleaned
+    WHERE assessed_value >= 0
+        AND tax_year >= 2015
 )
 
--- Step 3: Aggregate counts (deduplicated)
 SELECT
-  tax_year,
-  lower_bound,
-  upper_bound,
-  COUNT(DISTINCT parcel_number) AS property_count
+    tax_year,
+    lower_bound,
+    upper_bound,
+    COUNT(DISTINCT parcel_number) AS property_count
 FROM binned
-GROUP BY tax_year, lower_bound, upper_bound
-ORDER BY tax_year, lower_bound;
+GROUP BY
+    tax_year,
+    lower_bound,
+    upper_bound
+ORDER BY
+    tax_year,
+    lower_bound;

--- a/tasks/transform-tax-year-assessment-bins/sql/create_tax_year_assessment_bins.sql
+++ b/tasks/transform-tax-year-assessment-bins/sql/create_tax_year_assessment_bins.sql
@@ -1,0 +1,34 @@
+CREATE OR REPLACE TABLE `musa5090s26-team1.derived.tax_year_assessment_bins` AS
+
+-- Step 1: Clean and cast raw data
+WITH cleaned AS (
+  SELECT
+    CAST(year AS INT64) AS tax_year,
+    CAST(market_value AS NUMERIC) AS assessed_value,
+    parcel_number
+  FROM `musa5090s26-team1.source.opa_assessments`
+  WHERE market_value IS NOT NULL
+    AND year IS NOT NULL
+),
+
+-- Step 2: Create value bins
+binned AS (
+  SELECT
+    tax_year,
+    parcel_number,
+    CAST(FLOOR(assessed_value / 10000) * 10000 AS INT64) AS lower_bound,
+    CAST(FLOOR(assessed_value / 10000) * 10000 + 10000 AS INT64) AS upper_bound
+  FROM cleaned
+  WHERE assessed_value >= 0
+    AND tax_year >= 2015  -- remove incomplete years
+)
+
+-- Step 3: Aggregate counts (deduplicated)
+SELECT
+  tax_year,
+  lower_bound,
+  upper_bound,
+  COUNT(DISTINCT parcel_number) AS property_count
+FROM binned
+GROUP BY tax_year, lower_bound, upper_bound
+ORDER BY tax_year, lower_bound;


### PR DESCRIPTION
This PR implements Issue #7 by creating a derived table for tax year assessment value distributions.

- Created SQL to generate derived.tax_year_assessment_bins
- Binned market_value into $10,000 intervals
- Used COUNT(DISTINCT parcel_number) to handle duplicate records
- Filtered out incomplete years (pre-2015)

The table has been created and validated in BigQuery.