### PR TITLE
Issue 7

### DIFF
--- a/tasks/transform-tax-year-assessment-bins/main.py
+++ b/tasks/transform-tax-year-assessment-bins/main.py
@@ -1,0 +1,23 @@
+import pathlib
+import functions_framework
+from google.cloud import bigquery
+
+DIR_NAME = pathlib.Path(__file__).parent
+SQL_DIR_NAME = DIR_NAME / "sql"
+
+
+@functions_framework.http
+def run_sql(request):
+    sql_filename = request.args.get("sql", "create_derived_tax_year_assessment_bins.sql")
+    sql_path = SQL_DIR_NAME / sql_filename
+
+    if not sql_path.exists():
+        return f"SQL file not found: {sql_filename}", 404
+
+    with open(sql_path, "r", encoding="utf-8") as f:
+        sql_query = f.read()
+
+    client = bigquery.Client()
+    client.query_and_wait(sql_query)
+
+    return f"Successfully ran {sql_filename}"

--- a/tasks/transform-tax-year-assessment-bins/requirements.txt
+++ b/tasks/transform-tax-year-assessment-bins/requirements.txt
@@ -1,0 +1,2 @@
+functions-framework==3.*
+google-cloud-bigquery==3.*

--- a/tasks/transform-tax-year-assessment-bins/sql/create_derived_tax_year_assessment_bins.sql
+++ b/tasks/transform-tax-year-assessment-bins/sql/create_derived_tax_year_assessment_bins.sql
@@ -1,27 +1,29 @@
 CREATE OR REPLACE TABLE `derived.tax_year_assessment_bins` AS
 WITH cleaned AS (
-  SELECT
-    CAST(year AS INT64) AS tax_year,
-    CAST(market_value AS NUMERIC) AS market_value
-  FROM `source.opa_assessments`
-  WHERE year IS NOT NULL
-    AND market_value IS NOT NULL
-    AND SAFE_CAST(year AS INT64) IS NOT NULL
-    AND SAFE_CAST(market_value AS NUMERIC) IS NOT NULL
-    AND SAFE_CAST(market_value AS NUMERIC) >= 0
+    SELECT
+        CAST(year AS INT64) AS tax_year,
+        CAST(market_value AS NUMERIC) AS market_value
+    FROM `source.opa_assessments`
+    WHERE year IS NOT NULL
+        AND market_value IS NOT NULL
+        AND SAFE_CAST(year AS INT64) IS NOT NULL
+        AND SAFE_CAST(market_value AS NUMERIC) IS NOT NULL
+        AND SAFE_CAST(market_value AS NUMERIC) >= 0
 ),
+
 binned AS (
-  SELECT
-    tax_year,
-    CAST(FLOOR(market_value / 10000) * 10000 AS INT64) AS lower_bound,
-    CAST(FLOOR(market_value / 10000) * 10000 + 10000 AS INT64) AS upper_bound
-  FROM cleaned
+    SELECT
+        tax_year,
+        CAST(FLOOR(market_value / 10000) * 10000 AS INT64) AS lower_bound,
+        CAST(FLOOR(market_value / 10000) * 10000 + 10000 AS INT64) AS upper_bound
+    FROM cleaned
 )
+
 SELECT
-  tax_year,
-  lower_bound,
-  upper_bound,
-  COUNT(*) AS property_count
+    tax_year,
+    lower_bound,
+    upper_bound,
+    COUNT(*) AS property_count
 FROM binned
 GROUP BY tax_year, lower_bound, upper_bound
 ORDER BY tax_year, lower_bound;

--- a/tasks/transform-tax-year-assessment-bins/sql/create_derived_tax_year_assessment_bins.sql
+++ b/tasks/transform-tax-year-assessment-bins/sql/create_derived_tax_year_assessment_bins.sql
@@ -1,0 +1,27 @@
+CREATE OR REPLACE TABLE `derived.tax_year_assessment_bins` AS
+WITH cleaned AS (
+  SELECT
+    CAST(year AS INT64) AS tax_year,
+    CAST(market_value AS NUMERIC) AS market_value
+  FROM `source.opa_assessments`
+  WHERE year IS NOT NULL
+    AND market_value IS NOT NULL
+    AND SAFE_CAST(year AS INT64) IS NOT NULL
+    AND SAFE_CAST(market_value AS NUMERIC) IS NOT NULL
+    AND SAFE_CAST(market_value AS NUMERIC) >= 0
+),
+binned AS (
+  SELECT
+    tax_year,
+    CAST(FLOOR(market_value / 10000) * 10000 AS INT64) AS lower_bound,
+    CAST(FLOOR(market_value / 10000) * 10000 + 10000 AS INT64) AS upper_bound
+  FROM cleaned
+)
+SELECT
+  tax_year,
+  lower_bound,
+  upper_bound,
+  COUNT(*) AS property_count
+FROM binned
+GROUP BY tax_year, lower_bound, upper_bound
+ORDER BY tax_year, lower_bound;

--- a/tasks/transform-tax-year-assessment-bins/sql/create_derived_tax_year_assessment_bins.sql
+++ b/tasks/transform-tax-year-assessment-bins/sql/create_derived_tax_year_assessment_bins.sql
@@ -4,7 +4,8 @@ WITH cleaned AS (
         CAST(year AS INT64) AS tax_year,
         CAST(market_value AS NUMERIC) AS market_value
     FROM `source.opa_assessments`
-    WHERE year IS NOT NULL
+    WHERE
+        year IS NOT NULL
         AND market_value IS NOT NULL
         AND SAFE_CAST(year AS INT64) IS NOT NULL
         AND SAFE_CAST(market_value AS NUMERIC) IS NOT NULL
@@ -25,5 +26,10 @@ SELECT
     upper_bound,
     COUNT(*) AS property_count
 FROM binned
-GROUP BY tax_year, lower_bound, upper_bound
-ORDER BY tax_year, lower_bound;
+GROUP BY
+    tax_year,
+    lower_bound,
+    upper_bound
+ORDER BY
+    tax_year,
+    lower_bound;


### PR DESCRIPTION
This PR implements Issue #7 by adding a task to generate `derived.tax_year_assessment_bins`.

What this includes:
- A SQL script to create or replace `derived.tax_year_assessment_bins`
- A Cloud Function entry point (`main.py`) to run the SQL
- A `requirements.txt` file for deployment dependencies

The SQL:
- reads from `source.opa_assessments`
- uses `year` as `tax_year`
- bins `market_value` into $10,000 intervals
- counts records in each bin by year

Validation:
- the derived table was created successfully in BigQuery
- binned yearly totals match the filtered raw yearly counts
- resulting schema includes:
  - `tax_year`
  - `lower_bound`
  - `upper_bound`
  - `property_count`