### PR TITLE
Issue #5: Export current assessment bins JSON

### DIFF
--- a/tasks/export_current_assessment_bins/main.py
+++ b/tasks/export_current_assessment_bins/main.py
@@ -1,0 +1,89 @@
+import json
+import os
+
+import functions_framework
+from dotenv import load_dotenv
+from google.cloud import bigquery
+from google.cloud import storage
+
+load_dotenv()
+
+
+OUTPUT_OBJECT_NAME = "configs/current_assessment_bins.json"
+
+
+@functions_framework.http
+def export_current_assessment_bins(request):
+    del request
+
+    project_id = os.getenv("PROJECT_ID")
+    public_bucket = os.getenv("PUBLIC_BUCKET")
+    derived_dataset = os.getenv("BQ_DERIVED_DATASET", "derived")
+
+    if not project_id:
+        return (
+            json.dumps({"ok": False, "error": "Missing PROJECT_ID"}),
+            500,
+            {"Content-Type": "application/json"},
+        )
+
+    if not public_bucket:
+        return (
+            json.dumps({"ok": False, "error": "Missing PUBLIC_BUCKET"}),
+            500,
+            {"Content-Type": "application/json"},
+        )
+
+    sql = f"""
+    SELECT
+        lower_bound,
+        upper_bound,
+        property_count
+    FROM `{project_id}.{derived_dataset}.current_assessment_bins`
+    ORDER BY
+        lower_bound, upper_bound
+    """
+
+    try:
+        bigquery_client = bigquery.Client()
+        rows = bigquery_client.query(sql).result()
+
+        results = []
+        for row in rows:
+            results.append(
+                {
+                    "lower_bound": row.lower_bound,
+                    "upper_bound": row.upper_bound,
+                    "property_count": row.property_count,
+                }
+            )
+
+        payload = json.dumps(results)
+
+        storage_client = storage.Client()
+        bucket = storage_client.bucket(public_bucket)
+        blob = bucket.blob(OUTPUT_OBJECT_NAME)
+        blob.upload_from_string(
+            payload,
+            content_type="application/json",
+            timeout=600,
+        )
+
+        return (
+            json.dumps(
+                {
+                    "ok": True,
+                    "rows": len(results),
+                    "output_uri": f"gs://{public_bucket}/{OUTPUT_OBJECT_NAME}",
+                }
+            ),
+            200,
+            {"Content-Type": "application/json"},
+        )
+
+    except Exception as e:
+        return (
+            json.dumps({"ok": False, "error": str(e)}),
+            500,
+            {"Content-Type": "application/json"},
+        )

--- a/tasks/export_current_assessment_bins/requirements.txt
+++ b/tasks/export_current_assessment_bins/requirements.txt
@@ -1,0 +1,4 @@
+functions-framework==3.*
+google-cloud-bigquery
+google-cloud-storage
+python-dotenv


### PR DESCRIPTION
This PR implements Issue #5 for exporting current assessment distribution chart data.

What’s included:
* export-current-assessment-bins function

Details:
* queries derived.current_assessment_bins from BigQuery
* exports rows with lower_bound, upper_bound, and property_count
* writes JSON output to gs://musa5090s26-team1-public/configs/current_assessment_bins.json
* output is ordered by lower_bound for front-end use

Testing:
* tested successfully with functions-framework + curl
* confirmed 200 response
* confirmed output JSON written to the public bucket
* confirmed exported row count matches derived.current_assessment_bins