### PR TITLE
Repair Issue #3

### DIFF
--- a/tasks/pwd-parcels/load-pwd-parcels/sql/core_pwd_parcels.sql
+++ b/tasks/pwd-parcels/load-pwd-parcels/sql/core_pwd_parcels.sql
@@ -1,5 +1,5 @@
 CREATE OR REPLACE TABLE `__PROJECT_ID__.__BQ_CORE_DATASET__.pwd_parcels` AS
 SELECT
-    tencode AS property_id,
+    LPAD(CAST(brt_id AS STRING), 9, '0') AS property_id,
     *
 FROM `__PROJECT_ID__.__BQ_SOURCE_DATASET__.pwd_parcels`;


### PR DESCRIPTION
This PR repairs Issue #3 by updating the `core.pwd_parcels` load logic so that `property_id` is standardized from `brt_id` instead of `tencode`.

What’s included:
* update to `tasks/pwd-parcels/load-pwd-parcels/sql/core_pwd_parcels.sql`

Details:
* changes `core.pwd_parcels.property_id` to use `LPAD(CAST(brt_id AS STRING), 9, '0')`
* keeps the rest of the source PWD parcel fields unchanged
* aligns `core.pwd_parcels.property_id` with the OPA-style property ID format used in `core.opa_properties` and `core.opa_assessments`
* fixes the cross-table join issue caused by using `tencode` as `property_id`

Why this repair is needed:
* the previous implementation used `tencode` as `property_id`
* manual validation showed that `core.pwd_parcels.property_id` could not join to OPA-based `property_id`
* this repair brings the PWD core table closer to the project’s intended standardized property key

Testing:
* pulled updated branch in Cloud Shell
* reran `load-pwd-parcels`
* confirmed `core.pwd_parcels.property_id` now reflects padded `brt_id`
* confirmed joins between `core.pwd_parcels` and `core.opa_properties` no longer return zero matches