### PR TITLE
Repair Issue #3: Add parcel geometry to PWD parcels pipeline

### DIFF
--- a/tasks/pwd-parcels/extract-pwd-parcels/main.py
+++ b/tasks/pwd-parcels/extract-pwd-parcels/main.py
@@ -13,9 +13,9 @@ load_dotenv()
 
 DEFAULT_SOURCE_URL = (
     "https://hub.arcgis.com/api/v3/datasets/84baed491de44f539889f2af178ad85c_0/"
-    "downloads/data?format=csv&spatialRefId=3857&where=1%3D1"
+    "downloads/data?format=geojson&spatialRefId=4326&where=1%3D1"
 )
-RAW_OBJECT_NAME = "pwd_parcels/pwd_parcels.csv"
+RAW_OBJECT_NAME = "pwd_parcels/pwd_parcels.geojson"
 
 
 @functions_framework.http
@@ -33,13 +33,13 @@ def extract_pwd_parcels(request):
     source_url = os.getenv("PWD_PARCELS_URL", DEFAULT_SOURCE_URL)
 
     temp_dir = Path(tempfile.mkdtemp(dir="/tmp"))
-    local_csv = temp_dir / "pwd_parcels.csv"
+    local_geojson = temp_dir / "pwd_parcels.geojson"
 
     try:
         response = requests.get(source_url, stream=True, timeout=300)
         response.raise_for_status()
 
-        with local_csv.open("wb") as f:
+        with local_geojson.open("wb") as f:
             for chunk in response.iter_content(chunk_size=1024 * 1024):
                 if chunk:
                     f.write(chunk)
@@ -48,8 +48,8 @@ def extract_pwd_parcels(request):
         bucket = storage_client.bucket(raw_bucket)
         blob = bucket.blob(RAW_OBJECT_NAME)
         blob.upload_from_filename(
-            str(local_csv),
-            content_type="text/csv",
+            str(local_geojson),
+            content_type="application/geo+json",
             timeout=600,
         )
 
@@ -73,8 +73,8 @@ def extract_pwd_parcels(request):
 
     finally:
         try:
-            if local_csv.exists():
-                local_csv.unlink()
+            if local_geojson.exists():
+                local_geojson.unlink()
             temp_dir.rmdir()
         except Exception:
             pass

--- a/tasks/pwd-parcels/load-pwd-parcels/sql/core_pwd_parcels.sql
+++ b/tasks/pwd-parcels/load-pwd-parcels/sql/core_pwd_parcels.sql
@@ -1,5 +1,7 @@
 CREATE OR REPLACE TABLE `__PROJECT_ID__.__BQ_CORE_DATASET__.pwd_parcels` AS
 SELECT
+    LPAD(CAST(brt_id AS STRING), 9, '0') AS parcel_number,
     LPAD(CAST(brt_id AS STRING), 9, '0') AS property_id,
+    ST_GEOGFROMGEOJSON(geometry_geojson) AS geog,
     *
 FROM `__PROJECT_ID__.__BQ_SOURCE_DATASET__.pwd_parcels`;

--- a/tasks/pwd-parcels/load-pwd-parcels/sql/source_pwd_parcels.sql
+++ b/tasks/pwd-parcels/load-pwd-parcels/sql/source_pwd_parcels.sql
@@ -15,7 +15,8 @@ CREATE OR REPLACE EXTERNAL TABLE `__PROJECT_ID__.__BQ_SOURCE_DATASET__.pwd_parce
     pin STRING,
     parcel_id STRING,
     shape__area STRING,
-    shape__length STRING
+    shape__length STRING,
+    geometry_geojson STRING
 )
 OPTIONS (
     format = 'JSON',

--- a/tasks/pwd-parcels/prepare-pwd-parcels/main.py
+++ b/tasks/pwd-parcels/prepare-pwd-parcels/main.py
@@ -1,4 +1,3 @@
-import csv
 import json
 import os
 import tempfile
@@ -11,7 +10,7 @@ from google.cloud import storage
 load_dotenv()
 
 
-RAW_OBJECT_NAME = "pwd_parcels/pwd_parcels.csv"
+RAW_OBJECT_NAME = "pwd_parcels/pwd_parcels.geojson"
 PREPARED_OBJECT_NAME = "pwd_parcels/data.jsonl"
 
 
@@ -36,26 +35,38 @@ def prepare_pwd_parcels(request):
         )
 
     temp_dir = Path(tempfile.mkdtemp(dir="/tmp"))
-    local_csv = temp_dir / "pwd_parcels.csv"
+    local_geojson = temp_dir / "pwd_parcels.geojson"
     local_jsonl = temp_dir / "data.jsonl"
 
     try:
         storage_client = storage.Client()
 
         raw_blob = storage_client.bucket(raw_bucket).blob(RAW_OBJECT_NAME)
-        raw_blob.download_to_filename(str(local_csv))
+        raw_blob.download_to_filename(str(local_geojson))
 
         row_count = 0
 
-        with local_csv.open("r", encoding="utf-8-sig", newline="") as f_in, \
+        with local_geojson.open("r", encoding="utf-8-sig") as f_in, \
              local_jsonl.open("w", encoding="utf-8") as f_out:
 
-            reader = csv.DictReader(f_in)
+            data = json.load(f_in)
 
-            for row in reader:
+            for feature in data.get("features", []):
                 cleaned = {}
-                for key, value in row.items():
-                    cleaned[(key or "").strip().lower()] = value
+                for key, value in feature.get("properties", {}).items():
+                    if value is None:
+                        cleaned[(key or "").strip().lower()] = None
+                    else:
+                        cleaned[(key or "").strip().lower()] = str(value)
+
+                geometry = feature.get("geometry")
+                if geometry is None:
+                    cleaned["geometry_geojson"] = None
+                else:
+                    cleaned["geometry_geojson"] = json.dumps(
+                        geometry,
+                        ensure_ascii=False,
+                    )
 
                 f_out.write(json.dumps(cleaned, ensure_ascii=False) + "\n")
                 row_count += 1
@@ -88,8 +99,8 @@ def prepare_pwd_parcels(request):
 
     finally:
         try:
-            if local_csv.exists():
-                local_csv.unlink()
+            if local_geojson.exists():
+                local_geojson.unlink()
             if local_jsonl.exists():
                 local_jsonl.unlink()
             temp_dir.rmdir()


### PR DESCRIPTION
This PR repairs Issue #3 by updating the PWD parcels pipeline to preserve parcel geometry for downstream map-related tasks.

What’s included:
* update `extract-pwd-parcels` to download GeoJSON instead of CSV
* update `prepare-pwd-parcels` to emit JSONL rows with `geometry_geojson`
* update `source.pwd_parcels` schema to include `geometry_geojson`
* update `core.pwd_parcels` to produce `geog`
* preserve the standardized parcel key based on padded `brt_id`

Details:
* the previous implementation downloaded a CSV source, so `source.pwd_parcels` and `core.pwd_parcels` only contained parcel attributes and no geometry
* this repair changes the upstream source format to GeoJSON so parcel geometry is available in BigQuery
* `core.pwd_parcels` now includes:
  * `parcel_number`
  * `property_id`
  * `geog`
* `property_id` continues to use `LPAD(CAST(brt_id AS STRING), 9, '0')` so it remains compatible with OPA-based joins

Why this repair is needed:
* issue #32 and issue #6 require parcel geometry
* without geometry in `core.pwd_parcels`, `property_tile_info.geojson` and vector tile generation cannot be completed

Testing:
* reran `extract-pwd-parcels`
* reran `prepare-pwd-parcels`
* reran `load-pwd-parcels`
* confirmed `source.pwd_parcels` includes `geometry_geojson`
* confirmed `core.pwd_parcels` includes `geog`
* confirmed `core.pwd_parcels.property_id` still joins to OPA-based tables