### PR TITLE
Issue 18

### DIFF
--- a/ui/widget/index.html
+++ b/ui/widget/index.html
@@ -3,67 +3,79 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Property Owner Widget</title>
-
-  <link rel="stylesheet" href="https://unpkg.com/leaflet/dist/leaflet.css" />
+  <title>CAMA Widget</title>
   <link rel="stylesheet" href="./style.css" />
+  <link
+    rel="stylesheet"
+    href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
+    integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY="
+    crossorigin=""
+  />
+  <script src="https://cdn.jsdelivr.net/npm/apexcharts"></script>
 </head>
 <body>
-  <header class="topbar">
-    <div>
-      <h1>Property Value Viewer</h1>
-      <p>Check your property assessment, neighborhood context, and recent trends</p>
-    </div>
-  </header>
+  <div class="page">
+    <header class="page-header">
+      <h1>Philadelphia CAMA Widget</h1>
+      <p>Search and review parcel-level assessment information.</p>
+    </header>
 
-  <main class="page">
-    <section class="search-row">
-      <input id="addressInput" type="text" placeholder="Enter address (e.g., 123 Market St)" />
-      <button id="searchBtn">Search</button>
+    <section class="search-section card">
+      <div class="search-row">
+        <input
+          id="address-input"
+          type="text"
+          placeholder="Enter property address"
+        />
+        <button id="search-btn">Search</button>
+      </div>
     </section>
 
-    <section class="main-grid">
-      <div class="card summary-card">
-        <h2>Property Summary</h2>
-        <div class="summary-list">
-          <p><span>Address</span><strong id="addressText">123 Market St</strong></p>
-          <p><span>Current Value</span><strong id="valueText">$320,000</strong></p>
-          <p><span>Change</span><strong id="changeText" class="positive">+14%</strong></p>
-          <p><span>Neighborhood</span><strong id="neighborhoodText">Center City</strong></p>
+    <section class="content-grid">
+      <div class="left-column">
+        <div class="card summary-card">
+          <h2>Property Summary</h2>
+          <div class="summary-item">
+            <span class="label">Address</span>
+            <span id="property-address" class="value">N/A</span>
+          </div>
+          <div class="summary-item">
+            <span class="label">Current Market Value</span>
+            <span id="market-value" class="value">N/A</span>
+          </div>
+          <div class="summary-item">
+            <span class="label">Assessment Change</span>
+            <span id="value-change" class="value">N/A</span>
+          </div>
+          <div class="summary-item">
+            <span class="label">Neighborhood</span>
+            <span id="neighborhood" class="value">N/A</span>
+          </div>
+        </div>
+
+        <div class="card trend-card">
+          <h2>Most Recent Assessment Distribution</h2>
+          <p class="chart-subtitle">
+            Distribution of assessed property values in the latest tax year
+          </p>
+          <div id="latest-assessment-chart"></div>
         </div>
       </div>
 
-      <div class="card map-card">
-        <div class="card-header">
+      <div class="right-column">
+        <div class="card map-card">
           <h2>Map</h2>
-          <p>Property location and neighborhood context</p>
-        </div>
-        <div id="map"></div>
-      </div>
-    </section>
-
-    <section class="bottom-grid">
-      <div class="card trend-card">
-        <h2>Value Trend</h2>
-        <div class="trend-placeholder">
-          <div class="bar" style="height: 45%"><span>2022</span></div>
-          <div class="bar" style="height: 58%"><span>2023</span></div>
-          <div class="bar" style="height: 70%"><span>2024</span></div>
-          <div class="bar" style="height: 82%"><span>2025</span></div>
+          <div id="map"></div>
         </div>
       </div>
-
-      <div class="card explanation-card">
-        <h2>Explanation</h2>
-        <p id="explanationText">
-          This property’s assessed value increased in line with recent neighborhood trends.
-          The change may reflect surrounding market activity and comparable residential values.
-        </p>
-      </div>
     </section>
-  </main>
+  </div>
 
-  <script src="https://unpkg.com/leaflet/dist/leaflet.js"></script>
-  <script src="./main.js"></script>
+  <script
+    src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"
+    integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo="
+    crossorigin=""
+  ></script>
+  <script type="module" src="./main.js"></script>
 </body>
 </html>

--- a/ui/widget/index.html
+++ b/ui/widget/index.html
@@ -3,79 +3,69 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>CAMA Widget</title>
+  <title>Property Owner Widget</title>
+
+  <link rel="stylesheet" href="https://unpkg.com/leaflet/dist/leaflet.css" />
   <link rel="stylesheet" href="./style.css" />
-  <link
-    rel="stylesheet"
-    href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
-    integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY="
-    crossorigin=""
-  />
-  <script src="https://cdn.jsdelivr.net/npm/apexcharts"></script>
 </head>
 <body>
-  <div class="page">
-    <header class="page-header">
-      <h1>Philadelphia CAMA Widget</h1>
-      <p>Search and review parcel-level assessment information.</p>
-    </header>
+  <header class="topbar">
+    <div>
+      <h1>Property Value Viewer</h1>
+      <p>Check your property assessment, neighborhood context, and recent trends</p>
+    </div>
+  </header>
 
-    <section class="search-section card">
-      <div class="search-row">
-        <input
-          id="address-input"
-          type="text"
-          placeholder="Enter property address"
-        />
-        <button id="search-btn">Search</button>
-      </div>
+  <main class="page">
+    <section class="search-row">
+      <input id="addressInput" type="text" placeholder="Enter address (e.g., 123 Market St)" />
+      <button id="searchBtn">Search</button>
     </section>
 
-    <section class="content-grid">
-      <div class="left-column">
-        <div class="card summary-card">
-          <h2>Property Summary</h2>
-          <div class="summary-item">
-            <span class="label">Address</span>
-            <span id="property-address" class="value">N/A</span>
-          </div>
-          <div class="summary-item">
-            <span class="label">Current Market Value</span>
-            <span id="market-value" class="value">N/A</span>
-          </div>
-          <div class="summary-item">
-            <span class="label">Assessment Change</span>
-            <span id="value-change" class="value">N/A</span>
-          </div>
-          <div class="summary-item">
-            <span class="label">Neighborhood</span>
-            <span id="neighborhood" class="value">N/A</span>
-          </div>
-        </div>
-
-        <div class="card trend-card">
-          <h2>Most Recent Assessment Distribution</h2>
-          <p class="chart-subtitle">
-            Distribution of assessed property values in the latest tax year
-          </p>
-          <div id="latest-assessment-chart"></div>
+    <section class="main-grid">
+      <div class="card summary-card">
+        <h2>Property Summary</h2>
+        <div class="summary-list">
+          <p><span>Address</span><strong id="addressText">123 Market St</strong></p>
+          <p><span>Current Value</span><strong id="valueText">$320,000</strong></p>
+          <p><span>Change</span><strong id="changeText" class="positive">+14%</strong></p>
+          <p><span>Neighborhood</span><strong id="neighborhoodText">Center City</strong></p>
         </div>
       </div>
 
-      <div class="right-column">
-        <div class="card map-card">
+      <div class="card map-card">
+        <div class="card-header">
           <h2>Map</h2>
-          <div id="map"></div>
+          <p>Property location and neighborhood context</p>
         </div>
+        <div id="map"></div>
       </div>
     </section>
-  </div>
 
-  <script
-    src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"
-    integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo="
-    crossorigin=""
-  ></script>
-  <script type="module" src="./main.js"></script>
+    <section class="bottom-grid">
+      <div class="card trend-card">
+        <div class="card-header">
+          <h2>Value Distribution</h2>
+          <p id="latest-assessment-chart-helper">
+            Distribution of assessed property values for the latest assessment year
+          </p>
+        </div>
+        <div id="latest-assessment-chart-error" class="chart-error" role="status" aria-live="polite"></div>
+        <div id="latest-assessment-chart"></div>
+      </div>
+
+      <div class="card explanation-card">
+        <h2>Explanation</h2>
+        <p id="explanationText">
+          This property's assessed value increased in line with recent neighborhood trends.
+          The change may reflect surrounding market activity and comparable residential values.
+        </p>
+      </div>
+    </section>
+  </main>
+
+  <script src="https://unpkg.com/leaflet/dist/leaflet.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/apexcharts"></script>
+  <script src="./main.js"></script>
 </body>
 </html>

--- a/ui/widget/main.js
+++ b/ui/widget/main.js
@@ -63,48 +63,48 @@ function buildDisplayBins(rows) {
 
   while (lowerBound < MAIN_DISPLAY_MAX) {
     bins.push({
-      lower_bound: lowerBound,
-      upper_bound: lowerBound + MAIN_DISPLAY_BIN_SIZE,
-      property_count: 0,
+      lowerBound,
+      upperBound: lowerBound + MAIN_DISPLAY_BIN_SIZE,
+      propertyCount: 0,
       label: "",
-      tooltip_label: "",
-      is_overflow: false,
+      tooltipLabel: "",
+      isOverflow: false,
     });
     lowerBound += MAIN_DISPLAY_BIN_SIZE;
   }
 
   bins.push({
-    lower_bound: MAIN_DISPLAY_MAX,
-    upper_bound: null,
-    property_count: 0,
+    lowerBound: MAIN_DISPLAY_MAX,
+    upperBound: null,
+    propertyCount: 0,
     label: OVERFLOW_LABEL,
-    tooltip_label: `>${formatCurrency(MAIN_DISPLAY_MAX)}`,
-    is_overflow: true,
+    tooltipLabel: `>${formatCurrency(MAIN_DISPLAY_MAX)}`,
+    isOverflow: true,
   });
 
   for (const row of rows) {
-    if (row.lower_bound >= MAIN_DISPLAY_MAX || row.upper_bound > MAIN_DISPLAY_MAX) {
-      bins[bins.length - 1].property_count += row.property_count;
+    if (row.lowerBound >= MAIN_DISPLAY_MAX || row.upperBound > MAIN_DISPLAY_MAX) {
+      bins[bins.length - 1].propertyCount += row.propertyCount;
       continue;
     }
 
-    const index = Math.floor(row.lower_bound / MAIN_DISPLAY_BIN_SIZE);
+    const index = Math.floor(row.lowerBound / MAIN_DISPLAY_BIN_SIZE);
     if (bins[index]) {
-      bins[index].property_count += row.property_count;
+      bins[index].propertyCount += row.propertyCount;
     }
   }
 
   for (const bin of bins) {
-    if (bin.is_overflow) {
+    if (bin.isOverflow) {
       continue;
     }
 
-    bin.tooltip_label = `${formatCurrency(bin.lower_bound)} ${RANGE_SEPARATOR} ${formatCurrency(bin.upper_bound - 1)}`;
+    bin.tooltipLabel = `${formatCurrency(bin.lowerBound)} ${RANGE_SEPARATOR} ${formatCurrency(bin.upperBound - 1)}`;
 
-    if (bin.lower_bound === 0) {
+    if (bin.lowerBound === 0) {
       bin.label = "$0";
-    } else if (bin.lower_bound % 500000 === 0) {
-      bin.label = formatCompactCurrency(bin.lower_bound);
+    } else if (bin.lowerBound % 500000 === 0) {
+      bin.label = formatCompactCurrency(bin.lowerBound);
     } else {
       bin.label = "";
     }
@@ -118,7 +118,7 @@ function renderLatestAssessmentChart(rows, latestTaxYear) {
   const categories = rows.map((row) => row.label);
   const seriesData = rows.map((row) => ({
     x: row.label,
-    y: row.property_count,
+    y: row.propertyCount,
   }));
 
   destroyLatestAssessmentChart();
@@ -190,7 +190,7 @@ function renderLatestAssessmentChart(rows, latestTaxYear) {
     },
     tooltip: {
       x: {
-        formatter: (_value, { dataPointIndex }) => rows[dataPointIndex].tooltip_label,
+        formatter: (_value, { dataPointIndex }) => rows[dataPointIndex].tooltipLabel,
       },
       y: {
         formatter: (value) => `${formatNumber(value)} properties`,
@@ -225,7 +225,7 @@ async function loadLatestAssessmentChart() {
     }
 
     const taxYears = payload
-      .map((row) => Number(row.tax_year))
+      .map((row) => Number(row["tax_year"]))
       .filter((taxYear) => Number.isFinite(taxYear));
 
     if (taxYears.length === 0) {
@@ -236,19 +236,19 @@ async function loadLatestAssessmentChart() {
 
     const latestTaxYear = Math.max(...taxYears);
     const latestRows = payload
-      .filter((row) => Number(row.tax_year) === latestTaxYear)
+      .filter((row) => Number(row["tax_year"]) === latestTaxYear)
       .map((row) => ({
-        lower_bound: Number(row.lower_bound),
-        upper_bound: Number(row.upper_bound),
-        property_count: Number(row.property_count),
+        lowerBound: Number(row["lower_bound"]),
+        upperBound: Number(row["upper_bound"]),
+        propertyCount: Number(row["property_count"]),
       }))
       .filter(
         (row) =>
-          Number.isFinite(row.lower_bound) &&
-          Number.isFinite(row.upper_bound) &&
-          Number.isFinite(row.property_count),
+          Number.isFinite(row.lowerBound) &&
+          Number.isFinite(row.upperBound) &&
+          Number.isFinite(row.propertyCount),
       )
-      .sort((left, right) => left.lower_bound - right.lower_bound);
+      .sort((left, right) => left.lowerBound - right.lowerBound);
 
     if (latestRows.length === 0) {
       destroyLatestAssessmentChart();

--- a/ui/widget/main.js
+++ b/ui/widget/main.js
@@ -1,94 +1,142 @@
-const TAX_YEAR_BINS_URL =
-  "https://storage.googleapis.com/musa5090s26-team1-public/configs/tax_year_assessment_bins.json";
+const propertyData = {
+  address: "123 Market St",
+  value: "$320,000",
+  change: "+14%",
+  neighborhood: "Center City",
+  explanation:
+    "This property's assessed value increased in line with recent neighborhood trends. The change may reflect surrounding market activity and comparable residential values.",
+  lat: 39.9526,
+  lng: -75.1652,
+};
 
-const searchBtn = document.querySelector("#search-btn");
-const addressInput = document.querySelector("#address-input");
-const propertyAddress = document.querySelector("#property-address");
-const marketValue = document.querySelector("#market-value");
-const valueChange = document.querySelector("#value-change");
-const neighborhood = document.querySelector("#neighborhood");
+const TAX_YEAR_ASSESSMENT_BINS_URL =
+  "https://storage.googleapis.com/musa5090s26-team1-public/configs/tax_year_assessment_bins.json";
+const MAIN_DISPLAY_MAX = 2500000;
+const MAIN_DISPLAY_BIN_SIZE = 100000;
+const OVERFLOW_LABEL = ">$2.5M";
+const RANGE_SEPARATOR = "\u2013";
 
 let latestAssessmentChart = null;
 
 function formatCurrency(value) {
-  return `$${Number(value).toLocaleString()}`;
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    maximumFractionDigits: 0,
+  }).format(value);
 }
 
-function updateMockPropertySummary() {
-  const typedAddress = addressInput?.value?.trim();
-  propertyAddress.textContent = typedAddress || "1234 Market St, Philadelphia, PA";
-  marketValue.textContent = "$425,000";
-  valueChange.textContent = "+8.4%";
-  neighborhood.textContent = "Center City";
+function formatCompactCurrency(value) {
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    notation: "compact",
+    maximumFractionDigits: 1,
+  }).format(value);
 }
 
-function initSearch() {
-  if (!searchBtn) return;
-
-  searchBtn.addEventListener("click", () => {
-    updateMockPropertySummary();
-  });
+function formatNumber(value) {
+  return new Intl.NumberFormat("en-US").format(value);
 }
 
-function initMap() {
-  const mapContainer = document.querySelector("#map");
-  if (!mapContainer) return;
-
-  const map = L.map("map").setView([39.9526, -75.1652], 12);
-
-  L.tileLayer("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png", {
-    attribution: "&copy; OpenStreetMap contributors",
-  }).addTo(map);
-
-  L.marker([39.9526, -75.1652])
-    .addTo(map)
-    .bindPopup("Sample parcel location")
-    .openPopup();
+function setChartError(message = "") {
+  const errorElement = document.getElementById("latest-assessment-chart-error");
+  errorElement.textContent = message;
+  errorElement.style.display = message ? "block" : "none";
 }
 
-async function loadTaxYearAssessmentBins() {
-  const response = await fetch(TAX_YEAR_BINS_URL);
-  if (!response.ok) {
-    throw new Error(`Failed to fetch tax year bins: ${response.status}`);
-  }
-  return await response.json();
+function setChartHelperText(message) {
+  const helperElement = document.getElementById("latest-assessment-chart-helper");
+  helperElement.textContent = message;
 }
 
-function getMostRecentTaxYear(data) {
-  return Math.max(...data.map((d) => Number(d.tax_year)));
-}
-
-function filterLatestYearData(data) {
-  const mostRecentYear = getMostRecentTaxYear(data);
-
-  return data
-    .filter((d) => Number(d.tax_year) === mostRecentYear)
-    .sort((a, b) => Number(a.lower_bound) - Number(b.lower_bound));
-}
-
-function buildChartSeries(data) {
-  return data.map((d) => ({
-    x: Number(d.lower_bound),
-    y: Number(d.property_count),
-  }));
-}
-
-function renderLatestAssessmentChart(data) {
-  const chartContainer = document.querySelector("#latest-assessment-chart");
-  if (!chartContainer) return;
-
-  const seriesData = buildChartSeries(data);
-
+function destroyLatestAssessmentChart() {
   if (latestAssessmentChart) {
     latestAssessmentChart.destroy();
+    latestAssessmentChart = null;
+  }
+}
+
+function buildDisplayBins(rows) {
+  const bins = [];
+  let lowerBound = 0;
+
+  while (lowerBound < MAIN_DISPLAY_MAX) {
+    bins.push({
+      lower_bound: lowerBound,
+      upper_bound: lowerBound + MAIN_DISPLAY_BIN_SIZE,
+      property_count: 0,
+      label: "",
+      tooltip_label: "",
+      is_overflow: false,
+    });
+    lowerBound += MAIN_DISPLAY_BIN_SIZE;
   }
 
-  latestAssessmentChart = new ApexCharts(chartContainer, {
+  bins.push({
+    lower_bound: MAIN_DISPLAY_MAX,
+    upper_bound: null,
+    property_count: 0,
+    label: OVERFLOW_LABEL,
+    tooltip_label: `>${formatCurrency(MAIN_DISPLAY_MAX)}`,
+    is_overflow: true,
+  });
+
+  for (const row of rows) {
+    if (row.lower_bound >= MAIN_DISPLAY_MAX || row.upper_bound > MAIN_DISPLAY_MAX) {
+      bins[bins.length - 1].property_count += row.property_count;
+      continue;
+    }
+
+    const index = Math.floor(row.lower_bound / MAIN_DISPLAY_BIN_SIZE);
+    if (bins[index]) {
+      bins[index].property_count += row.property_count;
+    }
+  }
+
+  for (const bin of bins) {
+    if (bin.is_overflow) {
+      continue;
+    }
+
+    bin.tooltip_label = `${formatCurrency(bin.lower_bound)} ${RANGE_SEPARATOR} ${formatCurrency(bin.upper_bound - 1)}`;
+
+    if (bin.lower_bound === 0) {
+      bin.label = "$0";
+    } else if (bin.lower_bound % 500000 === 0) {
+      bin.label = formatCompactCurrency(bin.lower_bound);
+    } else {
+      bin.label = "";
+    }
+  }
+
+  return bins;
+}
+
+function renderLatestAssessmentChart(rows, latestTaxYear) {
+  const chartElement = document.getElementById("latest-assessment-chart");
+  const categories = rows.map((row) => row.label);
+  const seriesData = rows.map((row) => ({
+    x: row.label,
+    y: row.property_count,
+  }));
+
+  destroyLatestAssessmentChart();
+  setChartError("");
+  setChartHelperText(
+    `Latest assessment year (${latestTaxYear}) distribution. Main range shown up to $2.5M; higher values grouped into an overflow bin.`,
+  );
+
+  latestAssessmentChart = new window.ApexCharts(chartElement, {
     chart: {
       type: "bar",
-      height: 420,
+      height: 340,
       toolbar: {
         show: false,
+      },
+      animations: {
+        easing: "easeinout",
+        speed: 350,
       },
     },
     series: [
@@ -97,49 +145,55 @@ function renderLatestAssessmentChart(data) {
         data: seriesData,
       },
     ],
+    colors: ["#A64E30"],
     plotOptions: {
       bar: {
-        columnWidth: "85%",
+        borderRadius: 4,
+        columnWidth: "86%",
       },
     },
     dataLabels: {
       enabled: false,
     },
-    title: {
-      text: "Most Recent Assessment Year Distribution",
-      align: "left",
+    legend: {
+      show: false,
+    },
+    grid: {
+      borderColor: "#e5e7eb",
+      strokeDashArray: 4,
     },
     xaxis: {
-      type: "numeric",
-      title: {
-        text: "Assessment Value Lower Bound",
+      categories,
+      tickPlacement: "between",
+      axisBorder: {
+        color: "#cfd4dc",
+      },
+      axisTicks: {
+        color: "#cfd4dc",
       },
       labels: {
-        formatter(value) {
-          return formatCurrency(value);
-        },
+        rotate: 0,
+        trim: false,
+        hideOverlappingLabels: true,
+      },
+      title: {
+        text: "Assessed value range",
       },
     },
     yaxis: {
       title: {
-        text: "Number of Properties",
+        text: "Property count",
       },
       labels: {
-        formatter(value) {
-          return Number(value).toLocaleString();
-        },
+        formatter: (value) => formatNumber(Math.round(value)),
       },
     },
     tooltip: {
       x: {
-        formatter(value) {
-          return formatCurrency(value);
-        },
+        formatter: (_value, { dataPointIndex }) => rows[dataPointIndex].tooltip_label,
       },
       y: {
-        formatter(value) {
-          return `${Number(value).toLocaleString()} properties`;
-        },
+        formatter: (value) => `${formatNumber(value)} properties`,
       },
     },
   });
@@ -147,26 +201,98 @@ function renderLatestAssessmentChart(data) {
   latestAssessmentChart.render();
 }
 
-async function initLatestAssessmentChart() {
+async function loadLatestAssessmentChart() {
   try {
-    const rawData = await loadTaxYearAssessmentBins();
-    const latestYearData = filterLatestYearData(rawData);
-    renderLatestAssessmentChart(latestYearData);
-  } catch (error) {
-    console.error("Error loading latest assessment chart:", error);
+    setChartError("");
+    setChartHelperText(
+      "Distribution of assessed property values for the latest assessment year",
+    );
 
-    const chartContainer = document.querySelector("#latest-assessment-chart");
-    if (chartContainer) {
-      chartContainer.innerHTML =
-        '<p class="chart-error">Failed to load assessment distribution data.</p>';
+    if (!window.ApexCharts) {
+      throw new Error("Assessment chart library failed to load.");
     }
+
+    const response = await fetch(TAX_YEAR_ASSESSMENT_BINS_URL);
+    if (!response.ok) {
+      throw new Error(`Unable to load assessment chart data (${response.status}).`);
+    }
+
+    const payload = await response.json();
+    if (!Array.isArray(payload) || payload.length === 0) {
+      destroyLatestAssessmentChart();
+      setChartError("No assessment distribution data is available right now.");
+      return;
+    }
+
+    const taxYears = payload
+      .map((row) => Number(row.tax_year))
+      .filter((taxYear) => Number.isFinite(taxYear));
+
+    if (taxYears.length === 0) {
+      destroyLatestAssessmentChart();
+      setChartError("Assessment distribution data is missing tax year values.");
+      return;
+    }
+
+    const latestTaxYear = Math.max(...taxYears);
+    const latestRows = payload
+      .filter((row) => Number(row.tax_year) === latestTaxYear)
+      .map((row) => ({
+        lower_bound: Number(row.lower_bound),
+        upper_bound: Number(row.upper_bound),
+        property_count: Number(row.property_count),
+      }))
+      .filter(
+        (row) =>
+          Number.isFinite(row.lower_bound) &&
+          Number.isFinite(row.upper_bound) &&
+          Number.isFinite(row.property_count),
+      )
+      .sort((left, right) => left.lower_bound - right.lower_bound);
+
+    if (latestRows.length === 0) {
+      destroyLatestAssessmentChart();
+      setChartError(
+        `No assessment distribution bins were found for tax year ${latestTaxYear}.`,
+      );
+      return;
+    }
+
+    renderLatestAssessmentChart(buildDisplayBins(latestRows), latestTaxYear);
+  } catch (error) {
+    destroyLatestAssessmentChart();
+    setChartError(
+      error instanceof Error
+        ? error.message
+        : "Unable to load the latest assessment distribution chart.",
+    );
   }
 }
 
-function initApp() {
-  initSearch();
-  initMap();
-  initLatestAssessmentChart();
-}
+document.getElementById("searchBtn").addEventListener("click", () => {
+  const input = document.getElementById("addressInput").value.trim();
 
-initApp();
+  if (input) {
+    document.getElementById("addressText").textContent = input;
+  } else {
+    document.getElementById("addressText").textContent = propertyData.address;
+  }
+
+  document.getElementById("valueText").textContent = propertyData.value;
+  document.getElementById("changeText").textContent = propertyData.change;
+  document.getElementById("neighborhoodText").textContent = propertyData.neighborhood;
+  document.getElementById("explanationText").textContent = propertyData.explanation;
+});
+
+const map = L.map("map").setView([propertyData.lat, propertyData.lng], 14);
+
+L.tileLayer("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png", {
+  attribution: "&copy; OpenStreetMap contributors",
+}).addTo(map);
+
+L.marker([propertyData.lat, propertyData.lng])
+  .addTo(map)
+  .bindPopup("123 Market St")
+  .openPopup();
+
+loadLatestAssessmentChart();

--- a/ui/widget/main.js
+++ b/ui/widget/main.js
@@ -1,36 +1,172 @@
-const propertyData = {
-  address: "123 Market St",
-  value: "$320,000",
-  change: "+14%",
-  neighborhood: "Center City",
-  explanation:
-    "This property’s assessed value increased in line with recent neighborhood trends. The change may reflect surrounding market activity and comparable residential values.",
-  lat: 39.9526,
-  lng: -75.1652,
-};
+const TAX_YEAR_BINS_URL =
+  "https://storage.googleapis.com/musa5090s26-team1-public/configs/tax_year_assessment_bins.json";
 
-document.getElementById("searchBtn").addEventListener("click", () => {
-  const input = document.getElementById("addressInput").value.trim();
+const searchBtn = document.querySelector("#search-btn");
+const addressInput = document.querySelector("#address-input");
+const propertyAddress = document.querySelector("#property-address");
+const marketValue = document.querySelector("#market-value");
+const valueChange = document.querySelector("#value-change");
+const neighborhood = document.querySelector("#neighborhood");
 
-  if (input) {
-    document.getElementById("addressText").textContent = input;
-  } else {
-    document.getElementById("addressText").textContent = propertyData.address;
+let latestAssessmentChart = null;
+
+function formatCurrency(value) {
+  return `$${Number(value).toLocaleString()}`;
+}
+
+function updateMockPropertySummary() {
+  const typedAddress = addressInput?.value?.trim();
+  propertyAddress.textContent = typedAddress || "1234 Market St, Philadelphia, PA";
+  marketValue.textContent = "$425,000";
+  valueChange.textContent = "+8.4%";
+  neighborhood.textContent = "Center City";
+}
+
+function initSearch() {
+  if (!searchBtn) return;
+
+  searchBtn.addEventListener("click", () => {
+    updateMockPropertySummary();
+  });
+}
+
+function initMap() {
+  const mapContainer = document.querySelector("#map");
+  if (!mapContainer) return;
+
+  const map = L.map("map").setView([39.9526, -75.1652], 12);
+
+  L.tileLayer("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png", {
+    attribution: "&copy; OpenStreetMap contributors",
+  }).addTo(map);
+
+  L.marker([39.9526, -75.1652])
+    .addTo(map)
+    .bindPopup("Sample parcel location")
+    .openPopup();
+}
+
+async function loadTaxYearAssessmentBins() {
+  const response = await fetch(TAX_YEAR_BINS_URL);
+  if (!response.ok) {
+    throw new Error(`Failed to fetch tax year bins: ${response.status}`);
+  }
+  return await response.json();
+}
+
+function getMostRecentTaxYear(data) {
+  return Math.max(...data.map((d) => Number(d.tax_year)));
+}
+
+function filterLatestYearData(data) {
+  const mostRecentYear = getMostRecentTaxYear(data);
+
+  return data
+    .filter((d) => Number(d.tax_year) === mostRecentYear)
+    .sort((a, b) => Number(a.lower_bound) - Number(b.lower_bound));
+}
+
+function buildChartSeries(data) {
+  return data.map((d) => ({
+    x: Number(d.lower_bound),
+    y: Number(d.property_count),
+  }));
+}
+
+function renderLatestAssessmentChart(data) {
+  const chartContainer = document.querySelector("#latest-assessment-chart");
+  if (!chartContainer) return;
+
+  const seriesData = buildChartSeries(data);
+
+  if (latestAssessmentChart) {
+    latestAssessmentChart.destroy();
   }
 
-  document.getElementById("valueText").textContent = propertyData.value;
-  document.getElementById("changeText").textContent = propertyData.change;
-  document.getElementById("neighborhoodText").textContent = propertyData.neighborhood;
-  document.getElementById("explanationText").textContent = propertyData.explanation;
-});
+  latestAssessmentChart = new ApexCharts(chartContainer, {
+    chart: {
+      type: "bar",
+      height: 420,
+      toolbar: {
+        show: false,
+      },
+    },
+    series: [
+      {
+        name: "Properties",
+        data: seriesData,
+      },
+    ],
+    plotOptions: {
+      bar: {
+        columnWidth: "85%",
+      },
+    },
+    dataLabels: {
+      enabled: false,
+    },
+    title: {
+      text: "Most Recent Assessment Year Distribution",
+      align: "left",
+    },
+    xaxis: {
+      type: "numeric",
+      title: {
+        text: "Assessment Value Lower Bound",
+      },
+      labels: {
+        formatter(value) {
+          return formatCurrency(value);
+        },
+      },
+    },
+    yaxis: {
+      title: {
+        text: "Number of Properties",
+      },
+      labels: {
+        formatter(value) {
+          return Number(value).toLocaleString();
+        },
+      },
+    },
+    tooltip: {
+      x: {
+        formatter(value) {
+          return formatCurrency(value);
+        },
+      },
+      y: {
+        formatter(value) {
+          return `${Number(value).toLocaleString()} properties`;
+        },
+      },
+    },
+  });
 
-const map = L.map("map").setView([propertyData.lat, propertyData.lng], 14);
+  latestAssessmentChart.render();
+}
 
-L.tileLayer("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png", {
-  attribution: "&copy; OpenStreetMap contributors",
-}).addTo(map);
+async function initLatestAssessmentChart() {
+  try {
+    const rawData = await loadTaxYearAssessmentBins();
+    const latestYearData = filterLatestYearData(rawData);
+    renderLatestAssessmentChart(latestYearData);
+  } catch (error) {
+    console.error("Error loading latest assessment chart:", error);
 
-L.marker([propertyData.lat, propertyData.lng])
-  .addTo(map)
-  .bindPopup("123 Market St")
-  .openPopup();
+    const chartContainer = document.querySelector("#latest-assessment-chart");
+    if (chartContainer) {
+      chartContainer.innerHTML =
+        '<p class="chart-error">Failed to load assessment distribution data.</p>';
+    }
+  }
+}
+
+function initApp() {
+  initSearch();
+  initMap();
+  initLatestAssessmentChart();
+}
+
+initApp();

--- a/ui/widget/style.css
+++ b/ui/widget/style.css
@@ -1,189 +1,126 @@
-* {
-  box-sizing: border-box;
-}
-
 body {
   margin: 0;
   font-family: Arial, sans-serif;
-  background: #f3f4f6;
-  color: #1f2937;
-}
-
-.topbar {
-  background: #fff;
-  border-bottom: 1px solid #dcdfe4;
-  padding: 20px 24px;
-}
-
-.topbar h1 {
-  margin: 0 0 6px;
-  font-size: 2.2rem;
-}
-
-.topbar p {
-  margin: 0;
-  color: #6b7280;
-  font-size: 1rem;
+  background: #f7f7f8;
+  color: #222;
 }
 
 .page {
-  max-width: 1500px;
+  max-width: 1200px;
   margin: 0 auto;
-  padding: 16px 20px 24px;
+  padding: 24px;
 }
 
-.search-row {
-  display: grid;
-  grid-template-columns: 1fr 120px;
-  gap: 12px;
-  margin-bottom: 24px;
-}
-
-.search-row input {
-  padding: 14px 16px;
-  font-size: 1rem;
-  border: 1px solid #cfd4dc;
-  border-radius: 10px;
-  background: #fff;
-}
-
-.search-row button {
-  border: none;
-  border-radius: 10px;
-  background: #1f2937;
-  color: white;
-  font-size: 1rem;
-  cursor: pointer;
-}
-
-.search-row button:hover {
-  background: #111827;
-}
-
-.main-grid {
-  display: grid;
-  grid-template-columns: 1fr 1.3fr;
-  gap: 20px;
+.page-header {
   margin-bottom: 20px;
 }
 
-.bottom-grid {
-  display: grid;
-  grid-template-columns: 1.1fr 1fr;
-  gap: 20px;
+.page-header h1 {
+  margin: 0 0 8px;
+  font-size: 32px;
+}
+
+.page-header p {
+  margin: 0;
+  color: #666;
 }
 
 .card {
-  background: #fff;
-  border: 1px solid #dcdfe4;
-  border-radius: 16px;
-  padding: 22px;
-  box-shadow: 0 2px 8px rgb(0 0 0 / 4%);
+  background: white;
+  border-radius: 12px;
+  padding: 18px;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.06);
 }
 
-.card h2 {
-  margin: 0 0 18px;
-  font-size: 1.8rem;
+.search-section {
+  margin-bottom: 20px;
 }
 
-.summary-list {
+.search-row {
+  display: flex;
+  gap: 12px;
+}
+
+.search-row input {
+  flex: 1;
+  padding: 12px;
+  border: 1px solid #d9d9de;
+  border-radius: 8px;
+  font-size: 14px;
+}
+
+.search-row button {
+  padding: 12px 18px;
+  border: none;
+  border-radius: 8px;
+  cursor: pointer;
+}
+
+.content-grid {
+  display: grid;
+  grid-template-columns: 1.1fr 0.9fr;
+  gap: 20px;
+}
+
+.left-column,
+.right-column {
   display: flex;
   flex-direction: column;
-  gap: 18px;
+  gap: 20px;
 }
 
-.summary-list p {
+.summary-item {
   display: flex;
   justify-content: space-between;
   gap: 16px;
-  margin: 0;
-  padding-bottom: 12px;
-  border-bottom: 1px solid #edf0f3;
+  padding: 10px 0;
+  border-bottom: 1px solid #eee;
 }
 
-.summary-list span {
-  color: #6b7280;
+.summary-item:last-child {
+  border-bottom: none;
 }
 
-.summary-list strong {
-  font-size: 1.05rem;
+.summary-item .label {
+  color: #666;
 }
 
-.positive {
-  color: #0f766e;
+.summary-item .value {
+  font-weight: 600;
+  text-align: right;
 }
 
-.negative {
-  color: #b91c1c;
+.trend-card h2,
+.map-card h2,
+.summary-card h2 {
+  margin-top: 0;
 }
 
-.card-header {
-  margin-bottom: 12px;
+.chart-subtitle {
+  margin-top: -4px;
+  margin-bottom: 16px;
+  color: #666;
+  font-size: 14px;
 }
 
-.card-header h2 {
-  margin-bottom: 6px;
+#latest-assessment-chart {
+  width: 100%;
+  min-height: 420px;
 }
 
-.card-header p {
-  margin: 0;
-  color: #6b7280;
+.chart-error {
+  color: #b00020;
+  font-size: 14px;
 }
 
 #map {
   width: 100%;
-  height: 420px;
-  border-radius: 12px;
-  overflow: hidden;
-  border: 1px solid #e5e7eb;
+  min-height: 500px;
+  border-radius: 10px;
 }
 
-.trend-placeholder {
-  height: 280px;
-  display: flex;
-  align-items: end;
-  gap: 18px;
-  padding: 16px;
-  border: 1px dashed #c4c9d1;
-  border-radius: 12px;
-  background: #fafafa;
-}
-
-.bar {
-  flex: 1;
-  background: linear-gradient(180deg, #9ca3af, #4b5563);
-  border-radius: 10px 10px 0 0;
-  position: relative;
-  min-height: 40px;
-}
-
-.bar span {
-  position: absolute;
-  bottom: -28px;
-  left: 50%;
-  transform: translateX(-50%);
-  color: #4b5563;
-  font-size: 0.9rem;
-}
-
-.explanation-card p {
-  margin: 0;
-  line-height: 1.7;
-  color: #374151;
-  font-size: 1rem;
-}
-
-@media (width <=  960px) {
-  .main-grid,
-  .bottom-grid {
+@media (max-width: 900px) {
+  .content-grid {
     grid-template-columns: 1fr;
-  }
-
-  .search-row {
-    grid-template-columns: 1fr;
-  }
-
-  #map {
-    height: 320px;
   }
 }

--- a/ui/widget/style.css
+++ b/ui/widget/style.css
@@ -1,126 +1,191 @@
+* {
+  box-sizing: border-box;
+}
+
 body {
   margin: 0;
   font-family: Arial, sans-serif;
-  background: #f7f7f8;
-  color: #222;
+  background: #f3f4f6;
+  color: #1f2937;
+}
+
+.topbar {
+  background: #fff;
+  border-bottom: 1px solid #dcdfe4;
+  padding: 20px 24px;
+}
+
+.topbar h1 {
+  margin: 0 0 6px;
+  font-size: 2.2rem;
+}
+
+.topbar p {
+  margin: 0;
+  color: #6b7280;
+  font-size: 1rem;
 }
 
 .page {
-  max-width: 1200px;
+  max-width: 1500px;
   margin: 0 auto;
-  padding: 24px;
-}
-
-.page-header {
-  margin-bottom: 20px;
-}
-
-.page-header h1 {
-  margin: 0 0 8px;
-  font-size: 32px;
-}
-
-.page-header p {
-  margin: 0;
-  color: #666;
-}
-
-.card {
-  background: white;
-  border-radius: 12px;
-  padding: 18px;
-  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.06);
-}
-
-.search-section {
-  margin-bottom: 20px;
+  padding: 16px 20px 24px;
 }
 
 .search-row {
-  display: flex;
+  display: grid;
+  grid-template-columns: 1fr 120px;
   gap: 12px;
+  margin-bottom: 24px;
 }
 
 .search-row input {
-  flex: 1;
-  padding: 12px;
-  border: 1px solid #d9d9de;
-  border-radius: 8px;
-  font-size: 14px;
+  padding: 14px 16px;
+  font-size: 1rem;
+  border: 1px solid #cfd4dc;
+  border-radius: 10px;
+  background: #fff;
 }
 
 .search-row button {
-  padding: 12px 18px;
   border: none;
-  border-radius: 8px;
+  border-radius: 10px;
+  background: #1f2937;
+  color: white;
+  font-size: 1rem;
   cursor: pointer;
 }
 
-.content-grid {
+.search-row button:hover {
+  background: #111827;
+}
+
+.main-grid {
   display: grid;
-  grid-template-columns: 1.1fr 0.9fr;
+  grid-template-columns: 1fr 1.3fr;
+  gap: 20px;
+  margin-bottom: 20px;
+}
+
+.bottom-grid {
+  display: grid;
+  grid-template-columns: 1.1fr 1fr;
   gap: 20px;
 }
 
-.left-column,
-.right-column {
+.card {
+  background: #fff;
+  border: 1px solid #dcdfe4;
+  border-radius: 16px;
+  padding: 22px;
+  box-shadow: 0 2px 8px rgb(0 0 0 / 4%);
+}
+
+.card h2 {
+  margin: 0 0 18px;
+  font-size: 1.8rem;
+}
+
+.summary-list {
   display: flex;
   flex-direction: column;
-  gap: 20px;
+  gap: 18px;
 }
 
-.summary-item {
+.summary-list p {
   display: flex;
   justify-content: space-between;
   gap: 16px;
-  padding: 10px 0;
-  border-bottom: 1px solid #eee;
+  margin: 0;
+  padding-bottom: 12px;
+  border-bottom: 1px solid #edf0f3;
 }
 
-.summary-item:last-child {
-  border-bottom: none;
+.summary-list span {
+  color: #6b7280;
 }
 
-.summary-item .label {
-  color: #666;
+.summary-list strong {
+  font-size: 1.05rem;
 }
 
-.summary-item .value {
-  font-weight: 600;
-  text-align: right;
+.positive {
+  color: #0f766e;
 }
 
-.trend-card h2,
-.map-card h2,
-.summary-card h2 {
-  margin-top: 0;
+.negative {
+  color: #b91c1c;
 }
 
-.chart-subtitle {
-  margin-top: -4px;
-  margin-bottom: 16px;
-  color: #666;
-  font-size: 14px;
+.card-header {
+  margin-bottom: 12px;
 }
 
-#latest-assessment-chart {
-  width: 100%;
-  min-height: 420px;
+.card-header h2 {
+  margin-bottom: 6px;
 }
 
-.chart-error {
-  color: #b00020;
-  font-size: 14px;
+.card-header p {
+  margin: 0;
+  color: #6b7280;
 }
 
 #map {
   width: 100%;
-  min-height: 500px;
-  border-radius: 10px;
+  height: 420px;
+  border-radius: 12px;
+  overflow: hidden;
+  border: 1px solid #e5e7eb;
 }
 
-@media (max-width: 900px) {
-  .content-grid {
+.trend-card {
+  display: flex;
+  flex-direction: column;
+}
+
+.trend-card .card-header p {
+  max-width: 40rem;
+}
+
+#latest-assessment-chart {
+  min-height: 340px;
+  padding: 8px 4px 0;
+}
+
+.chart-error {
+  display: none;
+  margin-bottom: 12px;
+  padding: 12px 14px;
+  border: 1px solid #f1c7c7;
+  border-radius: 10px;
+  background: #fef2f2;
+  color: #991b1b;
+  font-size: 0.95rem;
+  line-height: 1.5;
+}
+
+.explanation-card p {
+  margin: 0;
+  line-height: 1.7;
+  color: #374151;
+  font-size: 1rem;
+}
+
+@media (width <= 960px) {
+  .main-grid,
+  .bottom-grid {
     grid-template-columns: 1fr;
+  }
+
+  .search-row {
+    grid-template-columns: 1fr;
+  }
+
+  #map {
+    height: 320px;
+  }
+
+  #latest-assessment-chart {
+    min-height: 300px;
   }
 }

--- a/ui/widget/style.css
+++ b/ui/widget/style.css
@@ -143,10 +143,6 @@ body {
   flex-direction: column;
 }
 
-.trend-card .card-header p {
-  max-width: 40rem;
-}
-
 #latest-assessment-chart {
   min-height: 340px;
   padding: 8px 4px 0;
@@ -169,6 +165,10 @@ body {
   line-height: 1.7;
   color: #374151;
   font-size: 1rem;
+}
+
+.trend-card .card-header p {
+  max-width: 40rem;
 }
 
 @media (width <= 960px) {


### PR DESCRIPTION
# Description

This PR completes Issue #18 by adding a chart that shows the distribution of assessed property values for the most recent assessment year in the widget UI.

The chart is designed to stay readable for a general audience by showing the main value range up to $2.5M and grouping higher-value properties into a final overflow bin. This avoids letting a very sparse high-end tail dominate the full x-axis while still preserving the presence of outliers.

Resolves #18

## Type of change
- New feature
- Small fix/change

## What changed
- Added a distribution chart for the most recent assessment year to the widget
- Updated the card title/text from “trend” framing to “distribution”
- Rendered the chart from the public assessment-bin JSON source
- Limited the main visible range to $2.5M for readability
- Grouped values above $2.5M into an overflow bin
- Fixed JS lint issues by renaming local identifiers to camelCase
- Fixed CSS lint issues by reordering selectors to satisfy stylelint

## Why this approach
The latest-year assessment distribution is extremely right-skewed, with a long sparse tail at very high values. Showing the full raw range directly makes the chart hard to read. The capped main range plus overflow bin keeps the primary market visible while still representing higher-value properties.

## What should the reviewer know?
- The chart uses the most recent assessment year only
- The widget layout was kept intact
- The visualization is intended to be readable on a normal laptop screen
- High-value outliers are not removed; they are grouped into a final overflow bin for clarity

## Post-merge follow-ups
- No action required