### PR TITLE
Refine historical assessment widget structure

### DIFF
--- a/ui/widget/index.html
+++ b/ui/widget/index.html
@@ -1,71 +1,121 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Property Owner Widget</title>
-
-  <link rel="stylesheet" href="https://unpkg.com/leaflet/dist/leaflet.css" />
-  <link rel="stylesheet" href="./style.css" />
-</head>
-<body>
-  <header class="topbar">
-    <div>
-      <h1>Property Value Viewer</h1>
-      <p>Check your property assessment, neighborhood context, and recent trends</p>
-    </div>
-  </header>
-
-  <main class="page">
-    <section class="search-row">
-      <input id="addressInput" type="text" placeholder="Enter address (e.g., 123 Market St)" />
-      <button id="searchBtn">Search</button>
-    </section>
-
-    <section class="main-grid">
-      <div class="card summary-card">
-        <h2>Property Summary</h2>
-        <div class="summary-list">
-          <p><span>Address</span><strong id="addressText">123 Market St</strong></p>
-          <p><span>Current Value</span><strong id="valueText">$320,000</strong></p>
-          <p><span>Change</span><strong id="changeText" class="positive">+14%</strong></p>
-          <p><span>Neighborhood</span><strong id="neighborhoodText">Center City</strong></p>
-        </div>
-      </div>
-
-      <div class="card map-card">
-        <div class="card-header">
-          <h2>Map</h2>
-          <p>Property location and neighborhood context</p>
-        </div>
-        <div id="map"></div>
-      </div>
-    </section>
-
-    <section class="bottom-grid">
-      <div class="card trend-card">
-        <div class="card-header">
-          <h2>Value Distribution</h2>
-          <p id="latest-assessment-chart-helper">
-            Distribution of assessed property values for the latest assessment year
-          </p>
-        </div>
-        <div id="latest-assessment-chart-error" class="chart-error" role="status" aria-live="polite"></div>
-        <div id="latest-assessment-chart"></div>
-      </div>
-
-      <div class="card explanation-card">
-        <h2>Explanation</h2>
-        <p id="explanationText">
-          This property's assessed value increased in line with recent neighborhood trends.
-          The change may reflect surrounding market activity and comparable residential values.
-        </p>
-      </div>
-    </section>
-  </main>
-
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Historical Assessment Value Widget</title>
+    <link rel="stylesheet" href="https://unpkg.com/leaflet/dist/leaflet.css" />
+    <link rel="stylesheet" href="./style.css" />
+  </head>
   <script src="https://unpkg.com/leaflet/dist/leaflet.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/apexcharts"></script>
   <script src="./main.js"></script>
-</body>
+  <body>
+    <main class="widget-page">
+      <header class="widget-header">
+        <p class="eyebrow">Property assessments</p>
+        <h1>Historical Assessment Value</h1>
+        <p class="intro">
+          View historical assessment values for a selected property using its
+          OPA ID.
+        </p>
+      </header>
+
+      <section class="lookup-panel" aria-label="Property lookup">
+        <label for="opaIdInput" class="input-label">OPA ID</label>
+        <div class="lookup-row">
+          <input
+            id="opaIdInput"
+            type="text"
+            inputmode="numeric"
+            placeholder="Enter OPA ID (e.g., 123456700)"
+            aria-describedby="opaIdHelp"
+          />
+          <button id="searchBtn" type="button">Look up property</button>
+        </div>
+        <p id="opaIdHelp" class="helper-text">
+          Enter a 9–10 digit OPA identifier to load property assessment history.
+        </p>
+      </section>
+
+      <section class="content-grid">
+        <article class="card summary-card" aria-labelledby="summary-heading">
+          <h2 id="summary-heading">Property summary</h2>
+          <dl class="summary-list">
+            <div class="summary-row">
+              <dt>OPA ID</dt>
+              <dd id="opaIdText">123456700</dd>
+            </div>
+            <div class="summary-row">
+              <dt>Address</dt>
+              <dd id="addressText">123 Market St</dd>
+            </div>
+            <div class="summary-row">
+              <dt>Current assessment</dt>
+              <dd id="currentValueText">$320,000</dd>
+            </div>
+            <div class="summary-row">
+              <dt>Tax year</dt>
+              <dd id="taxYearText">2025</dd>
+            </div>
+            <div class="summary-row">
+              <dt>Neighborhood</dt>
+              <dd id="neighborhoodText">Center City</dd>
+            </div>
+          </dl>
+        </article>
+
+        <article class="card map-card" aria-labelledby="map-heading">
+          <div class="card-header">
+            <h2 id="map-heading">Map</h2>
+            <p>Property location and surrounding context</p>
+          </div>
+          <div id="map"></div>
+        </article>
+      </section>
+
+      <section class="bottom-grid">
+        <article class="card trend-card" aria-labelledby="trend-heading">
+          <div class="card-header">
+            <h2 id="trend-heading">Assessment history</h2>
+            <p>Historical assessed values by tax year</p>
+          </div>
+          <div class="trend-placeholder" aria-hidden="true">
+            <div class="bar-group">
+              <div class="bar" style="height: 38%"></div>
+              <span>2021</span>
+            </div>
+            <div class="bar-group">
+              <div class="bar" style="height: 48%"></div>
+              <span>2022</span>
+            </div>
+            <div class="bar-group">
+              <div class="bar" style="height: 58%"></div>
+              <span>2023</span>
+            </div>
+            <div class="bar-group">
+              <div class="bar" style="height: 70%"></div>
+              <span>2024</span>
+            </div>
+            <div class="bar-group">
+              <div class="bar" style="height: 82%"></div>
+              <span>2025</span>
+            </div>
+          </div>
+        </article>
+
+        <article class="card notes-card" aria-labelledby="notes-heading">
+          <div class="card-header">
+            <h2 id="notes-heading">Notes</h2>
+            <p>Placeholder space for assessment context or methodology</p>
+          </div>
+          <p class="notes-text">
+            This area can be used later for explanatory text, metadata, or
+            links to assessment records.
+          </p>
+        </article>
+      </section>
+    </main>
+
+    <script src="./main.js"></script>
+  </body>
 </html>

--- a/ui/widget/main.js
+++ b/ui/widget/main.js
@@ -1,25 +1,25 @@
 const data = [
   {
-    property_id: "502244720",
+    propertyId: "502244720",
     address: "Sample property record",
     neighborhood: "Philadelphia",
     lat: 39.9526,
     lng: -75.1652,
     history: [
-      { year: "2015", market_value: 169600 },
-      { year: "2016", market_value: 169600 },
-      { year: "2017", market_value: 169600 },
-      { year: "2018", market_value: 169600 },
-      { year: "2019", market_value: 167000 },
-      { year: "2020", market_value: 169200 },
-      { year: "2021", market_value: 169200 },
-      { year: "2022", market_value: 169200 },
-      { year: "2023", market_value: 185000 },
-      { year: "2024", market_value: 185000 },
-      { year: "2025", market_value: 306700 },
-      { year: "2026", market_value: 306700 }
-    ]
-  }
+      { year: "2015", marketValue: 169600 },
+      { year: "2016", marketValue: 169600 },
+      { year: "2017", marketValue: 169600 },
+      { year: "2018", marketValue: 169600 },
+      { year: "2019", marketValue: 167000 },
+      { year: "2020", marketValue: 169200 },
+      { year: "2021", marketValue: 169200 },
+      { year: "2022", marketValue: 169200 },
+      { year: "2023", marketValue: 185000 },
+      { year: "2024", marketValue: 185000 },
+      { year: "2025", marketValue: 306700 },
+      { year: "2026", marketValue: 306700 },
+    ],
+  },
 ];
 
 let map = null;
@@ -28,7 +28,7 @@ let marker = null;
 const DEFAULT_VIEW = {
   lat: 39.9526,
   lng: -75.1652,
-  zoom: 12
+  zoom: 12,
 };
 
 function formatMoney(value) {
@@ -38,11 +38,11 @@ function formatMoney(value) {
 function initializeMap() {
   map = L.map("map").setView(
     [DEFAULT_VIEW.lat, DEFAULT_VIEW.lng],
-    DEFAULT_VIEW.zoom
+    DEFAULT_VIEW.zoom,
   );
 
   L.tileLayer("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png", {
-    attribution: "&copy; OpenStreetMap contributors"
+    attribution: "&copy; OpenStreetMap contributors",
   }).addTo(map);
 }
 
@@ -57,7 +57,7 @@ function updateMap(property) {
 
   marker = L.marker([property.lat, property.lng])
     .addTo(map)
-    .bindPopup(`${property.address}<br>OPA ID: ${property.property_id}`)
+    .bindPopup(`${property.address}<br>OPA ID: ${property.propertyId}`)
     .openPopup();
 }
 
@@ -94,7 +94,7 @@ function renderTrend(property) {
   trendContainer.innerHTML = "";
 
   const maxValue = Math.max(
-    ...property.history.map((item) => Number(item.market_value))
+    ...property.history.map((item) => Number(item.marketValue)),
   );
 
   property.history.forEach((item) => {
@@ -103,7 +103,7 @@ function renderTrend(property) {
 
     const bar = document.createElement("div");
     bar.className = "bar";
-    bar.style.height = `${(Number(item.market_value) / maxValue) * 100}%`;
+    bar.style.height = `${(Number(item.marketValue) / maxValue) * 100}%`;
 
     const label = document.createElement("span");
     label.textContent = item.year;
@@ -115,14 +115,14 @@ function renderTrend(property) {
 }
 
 function renderSummary(property) {
-  document.getElementById("opaIdText").textContent = property.property_id;
+  document.getElementById("opaIdText").textContent = property.propertyId;
   document.getElementById("addressText").textContent = property.address || "N/A";
   document.getElementById("neighborhoodText").textContent =
     property.neighborhood || "N/A";
 
   const latest = property.history[property.history.length - 1];
   document.getElementById("currentValueText").textContent = formatMoney(
-    latest.market_value
+    latest.marketValue,
   );
   document.getElementById("taxYearText").textContent = latest.year;
 }
@@ -139,7 +139,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
   document.getElementById("searchBtn").addEventListener("click", () => {
     const opaId = document.getElementById("opaIdInput").value.trim();
-    const match = data.find((item) => item.property_id === opaId);
+    const match = data.find((item) => item.propertyId === opaId);
 
     if (match) {
       renderProperty(match);

--- a/ui/widget/main.js
+++ b/ui/widget/main.js
@@ -1,298 +1,151 @@
-const propertyData = {
-  address: "123 Market St",
-  value: "$320,000",
-  change: "+14%",
-  neighborhood: "Center City",
-  explanation:
-    "This property's assessed value increased in line with recent neighborhood trends. The change may reflect surrounding market activity and comparable residential values.",
+const data = [
+  {
+    property_id: "502244720",
+    address: "Sample property record",
+    neighborhood: "Philadelphia",
+    lat: 39.9526,
+    lng: -75.1652,
+    history: [
+      { year: "2015", market_value: 169600 },
+      { year: "2016", market_value: 169600 },
+      { year: "2017", market_value: 169600 },
+      { year: "2018", market_value: 169600 },
+      { year: "2019", market_value: 167000 },
+      { year: "2020", market_value: 169200 },
+      { year: "2021", market_value: 169200 },
+      { year: "2022", market_value: 169200 },
+      { year: "2023", market_value: 185000 },
+      { year: "2024", market_value: 185000 },
+      { year: "2025", market_value: 306700 },
+      { year: "2026", market_value: 306700 }
+    ]
+  }
+];
+
+let map = null;
+let marker = null;
+
+const DEFAULT_VIEW = {
   lat: 39.9526,
   lng: -75.1652,
+  zoom: 12
 };
 
-const TAX_YEAR_ASSESSMENT_BINS_URL =
-  "https://storage.googleapis.com/musa5090s26-team1-public/configs/tax_year_assessment_bins.json";
-const MAIN_DISPLAY_MAX = 2500000;
-const MAIN_DISPLAY_BIN_SIZE = 100000;
-const OVERFLOW_LABEL = ">$2.5M";
-const RANGE_SEPARATOR = "\u2013";
-
-let latestAssessmentChart = null;
-
-function formatCurrency(value) {
-  return new Intl.NumberFormat("en-US", {
-    style: "currency",
-    currency: "USD",
-    maximumFractionDigits: 0,
-  }).format(value);
+function formatMoney(value) {
+  return `$${Number(value).toLocaleString()}`;
 }
 
-function formatCompactCurrency(value) {
-  return new Intl.NumberFormat("en-US", {
-    style: "currency",
-    currency: "USD",
-    notation: "compact",
-    maximumFractionDigits: 1,
-  }).format(value);
-}
-
-function formatNumber(value) {
-  return new Intl.NumberFormat("en-US").format(value);
-}
-
-function setChartError(message = "") {
-  const errorElement = document.getElementById("latest-assessment-chart-error");
-  errorElement.textContent = message;
-  errorElement.style.display = message ? "block" : "none";
-}
-
-function setChartHelperText(message) {
-  const helperElement = document.getElementById("latest-assessment-chart-helper");
-  helperElement.textContent = message;
-}
-
-function destroyLatestAssessmentChart() {
-  if (latestAssessmentChart) {
-    latestAssessmentChart.destroy();
-    latestAssessmentChart = null;
-  }
-}
-
-function buildDisplayBins(rows) {
-  const bins = [];
-  let lowerBound = 0;
-
-  while (lowerBound < MAIN_DISPLAY_MAX) {
-    bins.push({
-      lowerBound,
-      upperBound: lowerBound + MAIN_DISPLAY_BIN_SIZE,
-      propertyCount: 0,
-      label: "",
-      tooltipLabel: "",
-      isOverflow: false,
-    });
-    lowerBound += MAIN_DISPLAY_BIN_SIZE;
-  }
-
-  bins.push({
-    lowerBound: MAIN_DISPLAY_MAX,
-    upperBound: null,
-    propertyCount: 0,
-    label: OVERFLOW_LABEL,
-    tooltipLabel: `>${formatCurrency(MAIN_DISPLAY_MAX)}`,
-    isOverflow: true,
-  });
-
-  for (const row of rows) {
-    if (row.lowerBound >= MAIN_DISPLAY_MAX || row.upperBound > MAIN_DISPLAY_MAX) {
-      bins[bins.length - 1].propertyCount += row.propertyCount;
-      continue;
-    }
-
-    const index = Math.floor(row.lowerBound / MAIN_DISPLAY_BIN_SIZE);
-    if (bins[index]) {
-      bins[index].propertyCount += row.propertyCount;
-    }
-  }
-
-  for (const bin of bins) {
-    if (bin.isOverflow) {
-      continue;
-    }
-
-    bin.tooltipLabel = `${formatCurrency(bin.lowerBound)} ${RANGE_SEPARATOR} ${formatCurrency(bin.upperBound - 1)}`;
-
-    if (bin.lowerBound === 0) {
-      bin.label = "$0";
-    } else if (bin.lowerBound % 500000 === 0) {
-      bin.label = formatCompactCurrency(bin.lowerBound);
-    } else {
-      bin.label = "";
-    }
-  }
-
-  return bins;
-}
-
-function renderLatestAssessmentChart(rows, latestTaxYear) {
-  const chartElement = document.getElementById("latest-assessment-chart");
-  const categories = rows.map((row) => row.label);
-  const seriesData = rows.map((row) => ({
-    x: row.label,
-    y: row.propertyCount,
-  }));
-
-  destroyLatestAssessmentChart();
-  setChartError("");
-  setChartHelperText(
-    `Latest assessment year (${latestTaxYear}) distribution. Main range shown up to $2.5M; higher values grouped into an overflow bin.`,
+function initializeMap() {
+  map = L.map("map").setView(
+    [DEFAULT_VIEW.lat, DEFAULT_VIEW.lng],
+    DEFAULT_VIEW.zoom
   );
 
-  latestAssessmentChart = new window.ApexCharts(chartElement, {
-    chart: {
-      type: "bar",
-      height: 340,
-      toolbar: {
-        show: false,
-      },
-      animations: {
-        easing: "easeinout",
-        speed: 350,
-      },
-    },
-    series: [
-      {
-        name: "Properties",
-        data: seriesData,
-      },
-    ],
-    colors: ["#A64E30"],
-    plotOptions: {
-      bar: {
-        borderRadius: 4,
-        columnWidth: "86%",
-      },
-    },
-    dataLabels: {
-      enabled: false,
-    },
-    legend: {
-      show: false,
-    },
-    grid: {
-      borderColor: "#e5e7eb",
-      strokeDashArray: 4,
-    },
-    xaxis: {
-      categories,
-      tickPlacement: "between",
-      axisBorder: {
-        color: "#cfd4dc",
-      },
-      axisTicks: {
-        color: "#cfd4dc",
-      },
-      labels: {
-        rotate: 0,
-        trim: false,
-        hideOverlappingLabels: true,
-      },
-      title: {
-        text: "Assessed value range",
-      },
-    },
-    yaxis: {
-      title: {
-        text: "Property count",
-      },
-      labels: {
-        formatter: (value) => formatNumber(Math.round(value)),
-      },
-    },
-    tooltip: {
-      x: {
-        formatter: (_value, { dataPointIndex }) => rows[dataPointIndex].tooltipLabel,
-      },
-      y: {
-        formatter: (value) => `${formatNumber(value)} properties`,
-      },
-    },
+  L.tileLayer("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png", {
+    attribution: "&copy; OpenStreetMap contributors"
+  }).addTo(map);
+}
+
+function updateMap(property) {
+  if (!map) return;
+
+  map.setView([property.lat, property.lng], 15);
+
+  if (marker) {
+    map.removeLayer(marker);
+  }
+
+  marker = L.marker([property.lat, property.lng])
+    .addTo(map)
+    .bindPopup(`${property.address}<br>OPA ID: ${property.property_id}`)
+    .openPopup();
+}
+
+function resetSummary() {
+  document.getElementById("opaIdText").textContent = "—";
+  document.getElementById("addressText").textContent = "—";
+  document.getElementById("currentValueText").textContent = "—";
+  document.getElementById("taxYearText").textContent = "—";
+  document.getElementById("neighborhoodText").textContent = "—";
+}
+
+function resetTrend() {
+  const trendContainer = document.querySelector(".trend-placeholder");
+  trendContainer.innerHTML =
+    '<p class="empty-message">Assessment history will appear after lookup.</p>';
+}
+
+function resetView() {
+  resetSummary();
+  resetTrend();
+
+  if (map) {
+    map.setView([DEFAULT_VIEW.lat, DEFAULT_VIEW.lng], DEFAULT_VIEW.zoom);
+
+    if (marker) {
+      map.removeLayer(marker);
+      marker = null;
+    }
+  }
+}
+
+function renderTrend(property) {
+  const trendContainer = document.querySelector(".trend-placeholder");
+  trendContainer.innerHTML = "";
+
+  const maxValue = Math.max(
+    ...property.history.map((item) => Number(item.market_value))
+  );
+
+  property.history.forEach((item) => {
+    const group = document.createElement("div");
+    group.className = "bar-group";
+
+    const bar = document.createElement("div");
+    bar.className = "bar";
+    bar.style.height = `${(Number(item.market_value) / maxValue) * 100}%`;
+
+    const label = document.createElement("span");
+    label.textContent = item.year;
+
+    group.appendChild(bar);
+    group.appendChild(label);
+    trendContainer.appendChild(group);
   });
-
-  latestAssessmentChart.render();
 }
 
-async function loadLatestAssessmentChart() {
-  try {
-    setChartError("");
-    setChartHelperText(
-      "Distribution of assessed property values for the latest assessment year",
-    );
+function renderSummary(property) {
+  document.getElementById("opaIdText").textContent = property.property_id;
+  document.getElementById("addressText").textContent = property.address || "N/A";
+  document.getElementById("neighborhoodText").textContent =
+    property.neighborhood || "N/A";
 
-    if (!window.ApexCharts) {
-      throw new Error("Assessment chart library failed to load.");
-    }
-
-    const response = await fetch(TAX_YEAR_ASSESSMENT_BINS_URL);
-    if (!response.ok) {
-      throw new Error(`Unable to load assessment chart data (${response.status}).`);
-    }
-
-    const payload = await response.json();
-    if (!Array.isArray(payload) || payload.length === 0) {
-      destroyLatestAssessmentChart();
-      setChartError("No assessment distribution data is available right now.");
-      return;
-    }
-
-    const taxYears = payload
-      .map((row) => Number(row["tax_year"]))
-      .filter((taxYear) => Number.isFinite(taxYear));
-
-    if (taxYears.length === 0) {
-      destroyLatestAssessmentChart();
-      setChartError("Assessment distribution data is missing tax year values.");
-      return;
-    }
-
-    const latestTaxYear = Math.max(...taxYears);
-    const latestRows = payload
-      .filter((row) => Number(row["tax_year"]) === latestTaxYear)
-      .map((row) => ({
-        lowerBound: Number(row["lower_bound"]),
-        upperBound: Number(row["upper_bound"]),
-        propertyCount: Number(row["property_count"]),
-      }))
-      .filter(
-        (row) =>
-          Number.isFinite(row.lowerBound) &&
-          Number.isFinite(row.upperBound) &&
-          Number.isFinite(row.propertyCount),
-      )
-      .sort((left, right) => left.lowerBound - right.lowerBound);
-
-    if (latestRows.length === 0) {
-      destroyLatestAssessmentChart();
-      setChartError(
-        `No assessment distribution bins were found for tax year ${latestTaxYear}.`,
-      );
-      return;
-    }
-
-    renderLatestAssessmentChart(buildDisplayBins(latestRows), latestTaxYear);
-  } catch (error) {
-    destroyLatestAssessmentChart();
-    setChartError(
-      error instanceof Error
-        ? error.message
-        : "Unable to load the latest assessment distribution chart.",
-    );
-  }
+  const latest = property.history[property.history.length - 1];
+  document.getElementById("currentValueText").textContent = formatMoney(
+    latest.market_value
+  );
+  document.getElementById("taxYearText").textContent = latest.year;
 }
 
-document.getElementById("searchBtn").addEventListener("click", () => {
-  const input = document.getElementById("addressInput").value.trim();
+function renderProperty(property) {
+  renderSummary(property);
+  renderTrend(property);
+  updateMap(property);
+}
 
-  if (input) {
-    document.getElementById("addressText").textContent = input;
-  } else {
-    document.getElementById("addressText").textContent = propertyData.address;
-  }
+document.addEventListener("DOMContentLoaded", () => {
+  initializeMap();
+  resetView();
 
-  document.getElementById("valueText").textContent = propertyData.value;
-  document.getElementById("changeText").textContent = propertyData.change;
-  document.getElementById("neighborhoodText").textContent = propertyData.neighborhood;
-  document.getElementById("explanationText").textContent = propertyData.explanation;
+  document.getElementById("searchBtn").addEventListener("click", () => {
+    const opaId = document.getElementById("opaIdInput").value.trim();
+    const match = data.find((item) => item.property_id === opaId);
+
+    if (match) {
+      renderProperty(match);
+    } else {
+      alert("OPA ID not found in sample data.");
+      resetView();
+    }
+  });
 });
-
-const map = L.map("map").setView([propertyData.lat, propertyData.lng], 14);
-
-L.tileLayer("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png", {
-  attribution: "&copy; OpenStreetMap contributors",
-}).addTo(map);
-
-L.marker([propertyData.lat, propertyData.lng])
-  .addTo(map)
-  .bindPopup("123 Market St")
-  .openPopup();
-
-loadLatestAssessmentChart();

--- a/ui/widget/style.css
+++ b/ui/widget/style.css
@@ -4,9 +4,9 @@
 
 :root {
   --bg: #f0f0f0;
-  --surface: #ffffff;
+  --surface: #fff;
   --border: #d9d9d9;
-  --text: #222222;
+  --text: #222;
   --muted: #5c5c5c;
   --heading: #0f0f0f;
   --accent: #0d3b66;

--- a/ui/widget/style.css
+++ b/ui/widget/style.css
@@ -2,190 +2,259 @@
   box-sizing: border-box;
 }
 
+:root {
+  --bg: #f0f0f0;
+  --surface: #ffffff;
+  --border: #d9d9d9;
+  --text: #222222;
+  --muted: #5c5c5c;
+  --heading: #0f0f0f;
+  --accent: #0d3b66;
+  --accent-hover: #0a2f52;
+  --soft: #f7f7f7;
+}
+
 body {
   margin: 0;
-  font-family: Arial, sans-serif;
-  background: #f3f4f6;
-  color: #1f2937;
+  font-family: Arial, Helvetica, sans-serif;
+  background: var(--bg);
+  color: var(--text);
 }
 
-.topbar {
-  background: #fff;
-  border-bottom: 1px solid #dcdfe4;
-  padding: 20px 24px;
-}
-
-.topbar h1 {
-  margin: 0 0 6px;
-  font-size: 2.2rem;
-}
-
-.topbar p {
-  margin: 0;
-  color: #6b7280;
-  font-size: 1rem;
-}
-
-.page {
-  max-width: 1500px;
+.widget-page {
+  max-width: 1200px;
   margin: 0 auto;
-  padding: 16px 20px 24px;
+  padding: 24px;
 }
 
-.search-row {
-  display: grid;
-  grid-template-columns: 1fr 120px;
-  gap: 12px;
+.widget-header {
   margin-bottom: 24px;
 }
 
-.search-row input {
-  padding: 14px 16px;
+.eyebrow {
+  margin: 0 0 8px;
+  color: var(--accent);
+  font-size: 0.95rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.widget-header h1 {
+  margin: 0 0 8px;
+  font-size: 2rem;
+  line-height: 1.15;
+  color: var(--heading);
+}
+
+.intro {
+  margin: 0;
+  max-width: 700px;
+  color: var(--muted);
+  line-height: 1.5;
+}
+
+.lookup-panel,
+.card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+}
+
+.lookup-panel {
+  padding: 18px;
+  margin-bottom: 20px;
+}
+
+.input-label {
+  display: block;
+  margin-bottom: 8px;
+  font-weight: 700;
+}
+
+.lookup-row {
+  display: grid;
+  grid-template-columns: 1fr 180px;
+  gap: 12px;
+}
+
+.lookup-row input {
+  width: 100%;
+  padding: 12px 14px;
+  border: 1px solid #bfbfbf;
+  border-radius: 4px;
   font-size: 1rem;
-  border: 1px solid #cfd4dc;
-  border-radius: 10px;
   background: #fff;
 }
 
-.search-row button {
+.lookup-row input:focus {
+  outline: 2px solid #a3c9f1;
+  outline-offset: 1px;
+  border-color: var(--accent);
+}
+
+.lookup-row button {
   border: none;
-  border-radius: 10px;
-  background: #1f2937;
-  color: white;
+  border-radius: 4px;
+  background: var(--accent);
+  color: #fff;
   font-size: 1rem;
+  font-weight: 700;
   cursor: pointer;
+  padding: 12px 16px;
 }
 
-.search-row button:hover {
-  background: #111827;
+.lookup-row button:hover {
+  background: var(--accent-hover);
 }
 
-.main-grid {
+.helper-text {
+  margin: 8px 0 0;
+  color: var(--muted);
+  font-size: 0.92rem;
+}
+
+.content-grid {
   display: grid;
-  grid-template-columns: 1fr 1.3fr;
+  grid-template-columns: 360px 1fr;
   gap: 20px;
   margin-bottom: 20px;
 }
 
 .bottom-grid {
   display: grid;
-  grid-template-columns: 1.1fr 1fr;
+  grid-template-columns: 1.35fr 1fr;
   gap: 20px;
 }
 
 .card {
-  background: #fff;
-  border: 1px solid #dcdfe4;
-  border-radius: 16px;
-  padding: 22px;
-  box-shadow: 0 2px 8px rgb(0 0 0 / 4%);
-}
-
-.card h2 {
-  margin: 0 0 18px;
-  font-size: 1.8rem;
-}
-
-.summary-list {
-  display: flex;
-  flex-direction: column;
-  gap: 18px;
-}
-
-.summary-list p {
-  display: flex;
-  justify-content: space-between;
-  gap: 16px;
-  margin: 0;
-  padding-bottom: 12px;
-  border-bottom: 1px solid #edf0f3;
-}
-
-.summary-list span {
-  color: #6b7280;
-}
-
-.summary-list strong {
-  font-size: 1.05rem;
-}
-
-.positive {
-  color: #0f766e;
-}
-
-.negative {
-  color: #b91c1c;
+  padding: 20px;
 }
 
 .card-header {
-  margin-bottom: 12px;
+  margin-bottom: 14px;
 }
 
-.card-header h2 {
-  margin-bottom: 6px;
+.card h2 {
+  margin: 0 0 6px;
+  font-size: 1.35rem;
+  color: var(--heading);
 }
 
 .card-header p {
   margin: 0;
-  color: #6b7280;
+  color: var(--muted);
+  line-height: 1.4;
 }
+
+.summary-list {
+  margin: 0;
+}
+
+.summary-row {
+  display: grid;
+  grid-template-columns: 140px 1fr;
+  gap: 16px;
+  padding: 12px 0;
+  border-bottom: 1px solid #ececec;
+}
+
+.summary-row:first-child {
+  padding-top: 4px;
+}
+
+.summary-row:last-child {
+  border-bottom: none;
+  padding-bottom: 0;
+}
+
+.summary-row dt {
+  margin: 0;
+  color: var(--muted);
+}
+
+.summary-row dd {
+  margin: 0;
+  font-weight: 700;
+  color: var(--text);
+  text-align: right;
+}
+
 
 #map {
-  width: 100%;
-  height: 420px;
-  border-radius: 12px;
+  height: 400px;
+  border: 1px solid #d9d9d9;
+  border-radius: 4px;
   overflow: hidden;
-  border: 1px solid #e5e7eb;
+  background: #f7f7f7;
 }
 
-.trend-card {
+.empty-message {
+  min-height: 220px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #666;
+  font-weight: 600;
+  text-align: center;
+}
+
+.trend-placeholder {
+  height: 280px;
+  padding: 18px 12px 32px;
+  border: 1px dashed #bfbfbf;
+  border-radius: 4px;
+  background: var(--soft);
+  display: flex;
+  align-items: flex-end;
+  gap: 14px;
+}
+
+.bar-group {
+  flex: 1;
+  height: 100%;
   display: flex;
   flex-direction: column;
+  justify-content: flex-end;
+  align-items: center;
+  gap: 8px;
 }
 
-#latest-assessment-chart {
-  min-height: 340px;
-  padding: 8px 4px 0;
+.bar {
+  width: 100%;
+  max-width: 54px;
+  background: linear-gradient(180deg, #7aa6d1 0%, #0d3b66 100%);
+  border-radius: 4px 4px 0 0;
+  min-height: 24px;
 }
 
-.chart-error {
-  display: none;
-  margin-bottom: 12px;
-  padding: 12px 14px;
-  border: 1px solid #f1c7c7;
-  border-radius: 10px;
-  background: #fef2f2;
-  color: #991b1b;
-  font-size: 0.95rem;
-  line-height: 1.5;
+.bar-group span {
+  font-size: 0.88rem;
+  color: var(--muted);
 }
 
-.explanation-card p {
+.notes-text {
   margin: 0;
-  line-height: 1.7;
-  color: #374151;
-  font-size: 1rem;
+  color: var(--text);
+  line-height: 1.6;
 }
 
-.trend-card .card-header p {
-  max-width: 40rem;
-}
-
-@media (width <= 960px) {
-  .main-grid,
+@media (width <= 900px) {
+  .content-grid,
   .bottom-grid {
     grid-template-columns: 1fr;
   }
 
-  .search-row {
+  .lookup-row {
     grid-template-columns: 1fr;
   }
 
-  #map {
-    height: 320px;
+  .summary-row {
+    grid-template-columns: 1fr;
+    gap: 6px;
   }
 
-  #latest-assessment-chart {
-    min-height: 300px;
+  .summary-row dd {
+    text-align: left;
   }
 }


### PR DESCRIPTION
## Description
This PR refines the historical assessment value widget in `ui/widget/`.

It includes:
- an OPA ID lookup input
- a property summary section
- a map section for property context
- an assessment history section
- a notes section for supporting context
- updated sample historical assessment data for widget interaction

## Type of change
- [x] Small fix/change
- [ ] New feature
- [ ] Bug fix
- [ ] Documentation

Related to #17