### PR TITLE
Configure public bucket CORS

### DIFF
--- a/tasks/data-pipeline/CORS.md
+++ b/tasks/data-pipeline/CORS.md
@@ -1,0 +1,37 @@
+# Public Bucket CORS
+
+The frontend reads public dashboard assets directly from the team public GCS
+bucket. Browser fetch requests need CORS enabled on that bucket so the UI can
+load chart config JSON files and vector tiles.
+
+This config applies to:
+
+```text
+gs://musa5090s26-team1-public
+```
+
+The frontend reads these public asset URL patterns:
+
+```text
+https://storage.googleapis.com/musa5090s26-team1-public/configs/tax_year_assessment_bins.json
+https://storage.googleapis.com/musa5090s26-team1-public/configs/current_assessment_bins.json
+https://storage.googleapis.com/musa5090s26-team1-public/tiles/properties/{z}/{x}/{y}.pbf
+```
+
+## Apply CORS
+
+```bash
+gcloud storage buckets update gs://musa5090s26-team1-public \
+  --cors-file=tasks/data-pipeline/cors.json
+```
+
+## Verify CORS
+
+```bash
+gcloud storage buckets describe gs://musa5090s26-team1-public \
+  --format="default(cors_config)"
+```
+
+This task only configures public bucket CORS. It does not update
+`workflow.yaml`, Cloud Scheduler, Cloud Functions, Cloud Run jobs, frontend
+code, or package files.

--- a/tasks/data-pipeline/cors.json
+++ b/tasks/data-pipeline/cors.json
@@ -1,0 +1,8 @@
+[
+  {
+    "origin": ["*"],
+    "method": ["GET", "HEAD", "OPTIONS"],
+    "responseHeader": ["Content-Type"],
+    "maxAgeSeconds": 3600
+  }
+]


### PR DESCRIPTION
## Summary

This PR addresses issue #13 by adding a reproducible CORS configuration for the team public GCS bucket:

`gs://musa5090s26-team1-public`

The public bucket serves frontend assets used by the reviewer dashboard and property owner widget, including:

- chart config JSON files under `/configs/`
- vector tiles under `/tiles/`

This PR adds:

- `tasks/data-pipeline/cors.json`
- `tasks/data-pipeline/CORS.md`

## What changed

- Added a CORS JSON config that allows browser-based frontend requests from any origin.
- Allowed read-only methods needed by the UI:
  - `GET`
  - `HEAD`
  - `OPTIONS`
- Documented how to apply the CORS config using `gcloud storage buckets update`.
- Documented how to verify the bucket CORS config.
- Kept this PR scoped only to public bucket CORS.

## What this does not change

This PR does not modify:

- `workflow.yaml`
- Cloud Scheduler
- Cloud Functions
- Cloud Run jobs
- frontend code
- package files

Those will be handled separately after the remaining pipeline/frontend issues are completed.

## Verification

Applied the CORS config with:

```bash
gcloud storage buckets update gs://musa5090s26-team1-public \
  --cors-file=tasks/data-pipeline/cors.json