### PR TITLE
Export map style metadata

### DIFF
--- a/tasks/export_map_style_metadata/.gcloudignore
+++ b/tasks/export_map_style_metadata/.gcloudignore
@@ -1,0 +1,7 @@
+.gcloudignore
+.git
+.gitignore
+__pycache__/
+*.pyc
+env/
+.venv/

--- a/tasks/export_map_style_metadata/README.md
+++ b/tasks/export_map_style_metadata/README.md
@@ -1,0 +1,118 @@
+# Export Map Style Metadata
+
+This HTTP Cloud Function exports map styling metadata for the reviewer vector
+tile map. The frontend uses the metadata to build legends and default styling
+for numeric property tile fields that are not easy to summarize directly from
+vector tiles in the browser.
+
+## Frontend Contract
+
+Vector tile URL pattern:
+
+```text
+https://storage.googleapis.com/musa5090s26-team1-public/tiles/properties/{z}/{x}/{y}.pbf
+```
+
+Vector tile source layer:
+
+```text
+property_tile_info
+```
+
+Default style field:
+
+```text
+current_assessed_value
+```
+
+The metadata includes these fields:
+
+- `current_assessed_value`
+- `tax_year_assessed_value`
+- `absolute_change`
+- `percent_change`
+
+Each field includes:
+
+- `label`
+- `min`
+- `max`
+- `quantile_breakpoints`
+- `fixed_breakpoints`
+
+## Output
+
+GCS path:
+
+```text
+gs://musa5090s26-team1-public/configs/map_style_metadata.json
+```
+
+Public URL:
+
+```text
+https://storage.googleapis.com/musa5090s26-team1-public/configs/map_style_metadata.json
+```
+
+## Environment Variables
+
+All environment variables have defaults:
+
+- `PROJECT_ID`, default `musa5090s26-team1`
+- `BQ_CORE_DATASET`, default `core`
+- `BQ_DERIVED_DATASET`, default `derived`
+- `PUBLIC_BUCKET`, default `musa5090s26-team1-public`
+- `OUTPUT_BLOB`, default `configs/map_style_metadata.json`
+
+## Deploy
+
+```bash
+gcloud functions deploy export-map-style-metadata \
+  --gen2 \
+  --runtime=python312 \
+  --region=us-east4 \
+  --source=tasks/export_map_style_metadata \
+  --entry-point=export_map_style_metadata \
+  --trigger-http \
+  --no-allow-unauthenticated \
+  --set-env-vars PROJECT_ID=musa5090s26-team1,BQ_CORE_DATASET=core,BQ_DERIVED_DATASET=derived,PUBLIC_BUCKET=musa5090s26-team1-public,OUTPUT_BLOB=configs/map_style_metadata.json
+```
+
+## Test
+
+```bash
+functions-framework \
+  --target export_map_style_metadata \
+  --source tasks/export_map_style_metadata/main.py \
+  --port 8080
+```
+
+In another terminal:
+
+```bash
+curl -X POST http://localhost:8080/
+```
+
+To test the deployed authenticated function:
+
+```bash
+URL=$(gcloud functions describe export-map-style-metadata \
+  --gen2 \
+  --region=us-east4 \
+  --format="value(serviceConfig.uri)")
+
+TOKEN=$(gcloud auth print-identity-token --audiences="$URL")
+
+curl -X POST \
+  -H "Authorization: Bearer ${TOKEN}" \
+  "${URL}"
+```
+
+## Verify
+
+```bash
+gcloud storage ls gs://musa5090s26-team1-public/configs/map_style_metadata.json
+gcloud storage cat gs://musa5090s26-team1-public/configs/map_style_metadata.json
+```
+
+Workflow integration will be handled later.

--- a/tasks/export_map_style_metadata/README.md
+++ b/tasks/export_map_style_metadata/README.md
@@ -3,7 +3,9 @@
 This HTTP Cloud Function exports map styling metadata for the reviewer vector
 tile map. The frontend uses the metadata to build legends and default styling
 for numeric property tile fields that are not easy to summarize directly from
-vector tiles in the browser.
+vector tiles in the browser. The exported JSON also includes the vector tile
+connection settings, so the frontend can use `map_style_metadata.json` as the
+single map configuration contract.
 
 ## Frontend Contract
 
@@ -17,6 +19,12 @@ Vector tile source layer:
 
 ```text
 property_tile_info
+```
+
+Vector tile zoom range:
+
+```text
+12 to 18
 ```
 
 Default style field:
@@ -39,6 +47,13 @@ Each field includes:
 - `max`
 - `quantile_breakpoints`
 - `fixed_breakpoints`
+
+The top-level `vector_tiles` object includes:
+
+- `url_template`
+- `source_layer`
+- `minzoom`
+- `maxzoom`
 
 ## Output
 
@@ -63,6 +78,10 @@ All environment variables have defaults:
 - `BQ_DERIVED_DATASET`, default `derived`
 - `PUBLIC_BUCKET`, default `musa5090s26-team1-public`
 - `OUTPUT_BLOB`, default `configs/map_style_metadata.json`
+- `TILE_URL_TEMPLATE`, default `https://storage.googleapis.com/musa5090s26-team1-public/tiles/properties/{z}/{x}/{y}.pbf`
+- `TILE_SOURCE_LAYER`, default `property_tile_info`
+- `TILE_MINZOOM`, default `12`
+- `TILE_MAXZOOM`, default `18`
 
 ## Deploy
 

--- a/tasks/export_map_style_metadata/main.py
+++ b/tasks/export_map_style_metadata/main.py
@@ -14,6 +14,13 @@ DEFAULT_CORE_DATASET = "core"
 DEFAULT_DERIVED_DATASET = "derived"
 DEFAULT_PUBLIC_BUCKET = "musa5090s26-team1-public"
 DEFAULT_OUTPUT_BLOB = "configs/map_style_metadata.json"
+DEFAULT_TILE_URL_TEMPLATE = (
+    "https://storage.googleapis.com/musa5090s26-team1-public"
+    "/tiles/properties/{z}/{x}/{y}.pbf"
+)
+DEFAULT_TILE_SOURCE_LAYER = "property_tile_info"
+DEFAULT_TILE_MINZOOM = "12"
+DEFAULT_TILE_MAXZOOM = "18"
 
 FIELD_LABELS = {
     "current_assessed_value": "Current assessed value",
@@ -62,6 +69,10 @@ def export_map_style_metadata(request):
     derived_dataset = os.getenv("BQ_DERIVED_DATASET", DEFAULT_DERIVED_DATASET)
     public_bucket = os.getenv("PUBLIC_BUCKET", DEFAULT_PUBLIC_BUCKET)
     output_blob = os.getenv("OUTPUT_BLOB", DEFAULT_OUTPUT_BLOB)
+    tile_url_template = os.getenv("TILE_URL_TEMPLATE", DEFAULT_TILE_URL_TEMPLATE)
+    tile_source_layer = os.getenv("TILE_SOURCE_LAYER", DEFAULT_TILE_SOURCE_LAYER)
+    tile_minzoom = int(os.getenv("TILE_MINZOOM", DEFAULT_TILE_MINZOOM))
+    tile_maxzoom = int(os.getenv("TILE_MAXZOOM", DEFAULT_TILE_MAXZOOM))
 
     sql = f"""
     WITH latest_tax_year AS (
@@ -173,6 +184,12 @@ def export_map_style_metadata(request):
             "record_count": row["record_count"],
             "default_style_field": "current_assessed_value",
             "default_breakpoint_type": "quantile_breakpoints",
+            "vector_tiles": {
+                "url_template": tile_url_template,
+                "source_layer": tile_source_layer,
+                "minzoom": tile_minzoom,
+                "maxzoom": tile_maxzoom,
+            },
             "fields": fields,
         }
         payload = json.dumps(metadata)

--- a/tasks/export_map_style_metadata/main.py
+++ b/tasks/export_map_style_metadata/main.py
@@ -1,0 +1,192 @@
+import json
+import os
+from datetime import datetime
+from datetime import timezone
+
+import functions_framework
+from google.cloud import bigquery
+from google.cloud import storage
+
+
+DEFAULT_PROJECT_ID = "musa5090s26-team1"
+DEFAULT_CORE_DATASET = "core"
+DEFAULT_DERIVED_DATASET = "derived"
+DEFAULT_PUBLIC_BUCKET = "musa5090s26-team1-public"
+DEFAULT_OUTPUT_BLOB = "configs/map_style_metadata.json"
+
+FIELD_LABELS = {
+    "current_assessed_value": "Current assessed value",
+    "tax_year_assessed_value": "Latest tax year assessed value",
+    "absolute_change": "Absolute change",
+    "percent_change": "Percent change",
+}
+
+FIXED_BREAKPOINTS = {
+    "current_assessed_value": [100000, 250000, 500000, 750000, 1000000, 2500000],
+    "tax_year_assessed_value": [100000, 250000, 500000, 750000, 1000000, 2500000],
+    "absolute_change": [-250000, -100000, 0, 100000, 250000, 500000],
+    "percent_change": [-0.25, -0.1, 0, 0.1, 0.25, 0.5, 1.0],
+}
+
+
+@functions_framework.http
+def export_map_style_metadata(request):
+    del request
+
+    project_id = os.getenv("PROJECT_ID", DEFAULT_PROJECT_ID)
+    core_dataset = os.getenv("BQ_CORE_DATASET", DEFAULT_CORE_DATASET)
+    derived_dataset = os.getenv("BQ_DERIVED_DATASET", DEFAULT_DERIVED_DATASET)
+    public_bucket = os.getenv("PUBLIC_BUCKET", DEFAULT_PUBLIC_BUCKET)
+    output_blob = os.getenv("OUTPUT_BLOB", DEFAULT_OUTPUT_BLOB)
+
+    sql = f"""
+    WITH latest_tax_year AS (
+        SELECT
+            MAX(SAFE_CAST(year AS INT64)) AS tax_year
+        FROM `{project_id}.{core_dataset}.opa_assessments`
+        WHERE SAFE_CAST(year AS INT64) IS NOT NULL
+    ),
+
+    latest_assessments AS (
+        SELECT
+            assessments.property_id,
+            SAFE_CAST(assessments.market_value AS FLOAT64) AS tax_year_assessed_value
+        FROM `{project_id}.{core_dataset}.opa_assessments` AS assessments
+        CROSS JOIN latest_tax_year
+        WHERE SAFE_CAST(assessments.year AS INT64) = latest_tax_year.tax_year
+    ),
+
+    current_predictions AS (
+        SELECT
+            property_id,
+            SAFE_CAST(predicted_value AS FLOAT64) AS current_assessed_value
+        FROM `{project_id}.{derived_dataset}.current_assessments`
+        QUALIFY ROW_NUMBER() OVER (
+            PARTITION BY property_id
+            ORDER BY predicted_at DESC
+        ) = 1
+    ),
+
+    style_values AS (
+        SELECT
+            current_predictions.current_assessed_value,
+            latest_assessments.tax_year_assessed_value,
+            current_predictions.current_assessed_value
+                - latest_assessments.tax_year_assessed_value AS absolute_change,
+            SAFE_DIVIDE(
+                current_predictions.current_assessed_value
+                    - latest_assessments.tax_year_assessed_value,
+                latest_assessments.tax_year_assessed_value
+            ) AS percent_change
+        FROM `{project_id}.{core_dataset}.pwd_parcels` AS parcels
+        LEFT JOIN `{project_id}.{core_dataset}.opa_properties` AS properties
+            ON parcels.property_id = properties.property_id
+        LEFT JOIN current_predictions
+            ON parcels.property_id = current_predictions.property_id
+        LEFT JOIN latest_assessments
+            ON parcels.property_id = latest_assessments.property_id
+        WHERE
+            parcels.geog IS NOT NULL
+            AND parcels.property_id IS NOT NULL
+            AND properties.category_code_description IN (
+                'SINGLE FAMILY',
+                'MULTI FAMILY',
+                'APARTMENTS > 4 UNITS',
+                'VACANT LAND - RESIDENTIAL',
+                'GARAGE - RESIDENTIAL'
+            )
+    )
+
+    SELECT
+        COUNT(*) AS record_count,
+        MIN(current_assessed_value) AS current_assessed_value_min,
+        MAX(current_assessed_value) AS current_assessed_value_max,
+        ARRAY(
+            SELECT DISTINCT breakpoint
+            FROM UNNEST(APPROX_QUANTILES(current_assessed_value, 5)) AS breakpoint
+            WHERE breakpoint IS NOT NULL
+            ORDER BY breakpoint
+        ) AS current_assessed_value_quantiles,
+        MIN(tax_year_assessed_value) AS tax_year_assessed_value_min,
+        MAX(tax_year_assessed_value) AS tax_year_assessed_value_max,
+        ARRAY(
+            SELECT DISTINCT breakpoint
+            FROM UNNEST(APPROX_QUANTILES(tax_year_assessed_value, 5)) AS breakpoint
+            WHERE breakpoint IS NOT NULL
+            ORDER BY breakpoint
+        ) AS tax_year_assessed_value_quantiles,
+        MIN(absolute_change) AS absolute_change_min,
+        MAX(absolute_change) AS absolute_change_max,
+        ARRAY(
+            SELECT DISTINCT breakpoint
+            FROM UNNEST(APPROX_QUANTILES(absolute_change, 5)) AS breakpoint
+            WHERE breakpoint IS NOT NULL
+            ORDER BY breakpoint
+        ) AS absolute_change_quantiles,
+        MIN(percent_change) AS percent_change_min,
+        MAX(percent_change) AS percent_change_max,
+        ARRAY(
+            SELECT DISTINCT breakpoint
+            FROM UNNEST(APPROX_QUANTILES(percent_change, 5)) AS breakpoint
+            WHERE breakpoint IS NOT NULL
+            ORDER BY breakpoint
+        ) AS percent_change_quantiles
+    FROM style_values
+    """
+
+    try:
+        bigquery_client = bigquery.Client(project=project_id)
+        rows = list(bigquery_client.query(sql).result())
+        row = rows[0]
+
+        fields = {}
+        for field_name, label in FIELD_LABELS.items():
+            fields[field_name] = {
+                "label": label,
+                "min": row[f"{field_name}_min"],
+                "max": row[f"{field_name}_max"],
+                "quantile_breakpoints": list(row[f"{field_name}_quantiles"]),
+                "fixed_breakpoints": FIXED_BREAKPOINTS[field_name],
+            }
+
+        metadata = {
+            "generated_at": datetime.now(timezone.utc).isoformat(),
+            "source": "BigQuery",
+            "record_count": row["record_count"],
+            "default_style_field": "current_assessed_value",
+            "default_breakpoint_type": "quantile_breakpoints",
+            "fields": fields,
+        }
+        payload = json.dumps(metadata)
+
+        storage_client = storage.Client()
+        bucket = storage_client.bucket(public_bucket)
+        blob = bucket.blob(output_blob)
+        blob.upload_from_string(
+            payload,
+            content_type="application/json",
+            timeout=600,
+        )
+
+        output_uri = f"gs://{public_bucket}/{output_blob}"
+        public_url = f"https://storage.googleapis.com/{public_bucket}/{output_blob}"
+
+        return (
+            json.dumps(
+                {
+                    "ok": True,
+                    "output_uri": output_uri,
+                    "public_url": public_url,
+                    "record_count": row["record_count"],
+                }
+            ),
+            200,
+            {"Content-Type": "application/json"},
+        )
+
+    except Exception as e:
+        return (
+            json.dumps({"ok": False, "error": str(e)}),
+            500,
+            {"Content-Type": "application/json"},
+        )

--- a/tasks/export_map_style_metadata/main.py
+++ b/tasks/export_map_style_metadata/main.py
@@ -2,6 +2,7 @@ import json
 import os
 from datetime import datetime
 from datetime import timezone
+from decimal import Decimal
 
 import functions_framework
 from google.cloud import bigquery
@@ -27,6 +28,29 @@ FIXED_BREAKPOINTS = {
     "absolute_change": [-250000, -100000, 0, 100000, 250000, 500000],
     "percent_change": [-0.25, -0.1, 0, 0.1, 0.25, 0.5, 1.0],
 }
+
+
+def clean_breakpoints(values):
+    breakpoints = []
+    seen = set()
+
+    for value in values or []:
+        if value is None:
+            continue
+
+        if isinstance(value, Decimal):
+            value = float(value)
+
+        if isinstance(value, float) and value.is_integer():
+            value = int(value)
+
+        if value in seen:
+            continue
+
+        seen.add(value)
+        breakpoints.append(value)
+
+    return breakpoints
 
 
 @functions_framework.http
@@ -101,35 +125,27 @@ def export_map_style_metadata(request):
         COUNT(*) AS record_count,
         MIN(current_assessed_value) AS current_assessed_value_min,
         MAX(current_assessed_value) AS current_assessed_value_max,
-        ARRAY(
-            SELECT DISTINCT breakpoint
-            FROM UNNEST(APPROX_QUANTILES(current_assessed_value, 5)) AS breakpoint
-            WHERE breakpoint IS NOT NULL
-            ORDER BY breakpoint
+        APPROX_QUANTILES(
+            current_assessed_value,
+            5
         ) AS current_assessed_value_quantiles,
         MIN(tax_year_assessed_value) AS tax_year_assessed_value_min,
         MAX(tax_year_assessed_value) AS tax_year_assessed_value_max,
-        ARRAY(
-            SELECT DISTINCT breakpoint
-            FROM UNNEST(APPROX_QUANTILES(tax_year_assessed_value, 5)) AS breakpoint
-            WHERE breakpoint IS NOT NULL
-            ORDER BY breakpoint
+        APPROX_QUANTILES(
+            tax_year_assessed_value,
+            5
         ) AS tax_year_assessed_value_quantiles,
         MIN(absolute_change) AS absolute_change_min,
         MAX(absolute_change) AS absolute_change_max,
-        ARRAY(
-            SELECT DISTINCT breakpoint
-            FROM UNNEST(APPROX_QUANTILES(absolute_change, 5)) AS breakpoint
-            WHERE breakpoint IS NOT NULL
-            ORDER BY breakpoint
+        APPROX_QUANTILES(
+            absolute_change,
+            5
         ) AS absolute_change_quantiles,
         MIN(percent_change) AS percent_change_min,
         MAX(percent_change) AS percent_change_max,
-        ARRAY(
-            SELECT DISTINCT breakpoint
-            FROM UNNEST(APPROX_QUANTILES(percent_change, 5)) AS breakpoint
-            WHERE breakpoint IS NOT NULL
-            ORDER BY breakpoint
+        APPROX_QUANTILES(
+            percent_change,
+            5
         ) AS percent_change_quantiles
     FROM style_values
     """
@@ -145,7 +161,9 @@ def export_map_style_metadata(request):
                 "label": label,
                 "min": row[f"{field_name}_min"],
                 "max": row[f"{field_name}_max"],
-                "quantile_breakpoints": list(row[f"{field_name}_quantiles"]),
+                "quantile_breakpoints": clean_breakpoints(
+                    row[f"{field_name}_quantiles"]
+                ),
                 "fixed_breakpoints": FIXED_BREAKPOINTS[field_name],
             }
 

--- a/tasks/export_map_style_metadata/requirements.txt
+++ b/tasks/export_map_style_metadata/requirements.txt
@@ -1,0 +1,3 @@
+functions-framework
+google-cloud-bigquery
+google-cloud-storage


### PR DESCRIPTION
## Summary

This PR implements issue #20 by adding a new Cloud Function task:

`tasks/export_map_style_metadata`

The function exports map styling metadata for the reviewer vector tile map to:

`gs://musa5090s26-team1-public/configs/map_style_metadata.json`

Public URL:

`https://storage.googleapis.com/musa5090s26-team1-public/configs/map_style_metadata.json`

## Frontend contract

The metadata JSON is designed for the reviewer map vector tile layer.

Vector tile URL pattern:

`https://storage.googleapis.com/musa5090s26-team1-public/tiles/properties/{z}/{x}/{y}.pbf`

Vector tile source layer:

`property_tile_info`

Default style field:

`current_assessed_value`

Default breakpoint type:

`quantile_breakpoints`

The metadata includes these fields:

- `current_assessed_value`
- `tax_year_assessed_value`
- `absolute_change`
- `percent_change`

Each field includes:

- `label`
- `min`
- `max`
- `quantile_breakpoints`
- `fixed_breakpoints`

The frontend can default to `quantile_breakpoints`, while `fixed_breakpoints` are also included as a fallback / easier-to-explain legend option.

## Implementation notes

The function:

- queries BigQuery for current model predictions and latest official tax-year assessments;
- computes:
  - current assessed value
  - latest tax-year assessed value
  - absolute change
  - percent change
- computes data-driven quantile breakpoints;
- includes fixed breakpoints for each field;
- uploads the resulting JSON to the public bucket.

This PR intentionally does **not** update:

- `tasks/data-pipeline/workflow.yaml`
- Cloud Scheduler
- frontend code
- existing Cloud Functions or Cloud Run jobs

Workflow integration will be handled later after the remaining pipeline/frontend issues are complete.

## Verification

Deployed the function:

```bash
gcloud functions deploy export-map-style-metadata \
  --gen2 \
  --runtime python312 \
  --region us-east4 \
  --source tasks/export_map_style_metadata \
  --entry-point export_map_style_metadata \
  --trigger-http \
  --no-allow-unauthenticated \
  --set-env-vars PROJECT_ID=musa5090s26-team1,BQ_CORE_DATASET=core,BQ_DERIVED_DATASET=derived,PUBLIC_BUCKET=musa5090s26-team1-public,OUTPUT_BLOB=configs/map_style_metadata.json