### PR TITLE
Update create_derived_current_assessments_model_training_data.sql

### DIFF
--- a/tasks/transform-model-training-data/sql/create_derived_current_assessments_model_training_data.sql
+++ b/tasks/transform-model-training-data/sql/create_derived_current_assessments_model_training_data.sql
@@ -1,35 +1,101 @@
-CREATE OR REPLACE TABLE `derived.current_assessments_model_training_data` AS
-SELECT
-    ca.parcel_number,
+CREATE OR REPLACE TABLE `musa5090s26-team1.derived.current_assessments_model_training_data` AS
+WITH latest_assessments AS (
+    SELECT
+        parcel_number,
+        SAFE_CAST(year AS INT64) AS assessment_year,
+        SAFE_CAST(market_value AS FLOAT64) AS current_market_value,
+        SAFE_CAST(taxable_land AS FLOAT64) AS taxable_land,
+        SAFE_CAST(taxable_building AS FLOAT64) AS taxable_building,
+        SAFE_CAST(exempt_land AS FLOAT64) AS exempt_land,
+        SAFE_CAST(exempt_building AS FLOAT64) AS exempt_building,
+        ROW_NUMBER() OVER (
+            PARTITION BY parcel_number
+            ORDER BY SAFE_CAST(year AS INT64) DESC
+        ) AS rn
+    FROM `musa5090s26-team1.core.opa_assessments`
+    WHERE SAFE_CAST(year AS INT64) IS NOT NULL
+)
 
+SELECT
+    -- ID
+    p.parcel_number,
+    p.property_id,
+
+    -- TARGET
     SAFE_CAST(p.sale_price AS FLOAT64) AS target_sale_price,
 
-    ca.bedrooms,
-    ca.bathrooms,
-    ca.rooms,
-    ca.stories,
-    ca.garage_spaces,
+    -- CURRENT ASSESSMENT / TAX FEATURES
+    la.assessment_year,
+    la.current_market_value,
+    la.taxable_land,
+    la.taxable_building,
+    la.exempt_land,
+    la.exempt_building,
 
-    ca.quality_grade,
-    ca.interior_condition,
-    ca.exterior_condition,
+    -- STRUCTURAL FEATURES
+    SAFE_CAST(p.number_of_bedrooms AS FLOAT64) AS bedrooms,
+    SAFE_CAST(p.number_of_bathrooms AS FLOAT64) AS bathrooms,
+    SAFE_CAST(p.number_of_rooms AS FLOAT64) AS rooms,
+    SAFE_CAST(p.number_stories AS FLOAT64) AS stories,
+    SAFE_CAST(p.garage_spaces AS FLOAT64) AS garage_spaces,
+    SAFE_CAST(p.basements AS FLOAT64) AS basements,
+    SAFE_CAST(p.total_area AS FLOAT64) AS total_area,
+    SAFE_CAST(p.total_livable_area AS FLOAT64) AS total_livable_area,
+    SAFE_CAST(p.frontage AS FLOAT64) AS frontage,
+    SAFE_CAST(p.depth AS FLOAT64) AS depth,
+    SAFE_CAST(p.year_built AS FLOAT64) AS year_built,
+    SAFE_CAST(p.year_built_estimate AS FLOAT64) AS year_built_estimate,
 
-    ca.category_code,
-    ca.category_code_description,
+    -- QUALITY / CONDITION
+    p.quality_grade,
+    p.interior_condition,
+    p.exterior_condition,
+    p.general_construction,
+    p.building_code,
+    p.building_code_description,
+    p.building_code_new,
+    p.building_code_description_new,
 
-    ca.taxable_land,
-    ca.taxable_building,
+    -- PROPERTY / USE TYPE
+    p.category_code,
+    p.category_code_description,
+    p.garage_type,
+    p.fuel,
+    p.type_heater,
+    p.central_air,
+    p.other_building,
+    p.off_street_open,
+    p.unfinished,
+    p.view_type,
+    p.house_extension,
 
-    ca.market_value AS current_market_value,
+    -- PARCEL / LOCATION FEATURES
+    p.parcel_shape,
+    p.shape,
+    p.topography,
+    p.site_type,
+    p.zoning,
+    p.zip_code,
+    p.census_tract,
+    p.geographic_ward,
+    p.location,
 
-    ca.assessment_year
+    -- UTILITIES / SERVICES
+    p.separate_utilities,
+    p.sewer,
+    p.utility,
 
-FROM `derived.current_assessments` AS ca
-JOIN `core.opa_properties` AS p
-    ON ca.parcel_number = p.parcel_number
+    -- TIME
+    p.sale_date,
+    p.market_value_date
+
+FROM `musa5090s26-team1.core.opa_properties` AS p
+JOIN latest_assessments AS la
+    ON p.parcel_number = la.parcel_number
 
 WHERE
-    SAFE_CAST(p.sale_price AS FLOAT64) IS NOT NULL
+    la.rn = 1
+    AND SAFE_CAST(p.sale_price AS FLOAT64) IS NOT NULL
     AND SAFE_CAST(p.sale_price AS FLOAT64) > 1000
     AND SAFE_CAST(p.sale_price AS FLOAT64) < 5000000
-    AND ca.market_value IS NOT NULL;
+    AND la.current_market_value IS NOT NULL;


### PR DESCRIPTION
Resolves #9

## Summary

This PR updates Issue #9 by rebuilding `derived.current_assessments_model_training_data` so it matches the current repo schema and pipeline design.

The original training-data SQL depended on `derived.current_assessments` as if it were still a wide feature table. That is no longer correct, because `derived.current_assessments` is now used as a prediction-output table. This update rebuilds the training dataset from the proper upstream source tables instead.

## What changed

- Rebuilt `derived.current_assessments_model_training_data`
- Stopped using `derived.current_assessments` as the source of model-training features
- Pulled latest assessment / tax features from `core.opa_assessments`
- Pulled structural, condition, parcel, utility, and sale-price fields from `core.opa_properties`
- Kept the training table at one row per parcel using the most recent assessment record
- Preserved the original target design using `sale_price` as `target_sale_price`
- Restored the older property feature fields where they still exist in the current schema

## Why this change was needed

Issue #9 was written against an older schema where `derived.current_assessments` still exposed many assessment and parcel feature columns. After later pipeline changes, that table no longer serves as the correct upstream source for model training.

Without this fix, the old SQL referenced fields that no longer exist in the current table design. This update aligns Issue #9 with the current repo state and restores a valid training-data build step.

## Current training-data logic

The updated training table now uses:

- `core.opa_assessments` for the latest assessment-year and tax-related fields:
  - `assessment_year`
  - `current_market_value`
  - `taxable_land`
  - `taxable_building`
  - `exempt_land`
  - `exempt_building`

- `core.opa_properties` for:
  - `target_sale_price`
  - structural features
  - quality / condition fields
  - property / use type fields
  - parcel / location fields
  - utilities / services
  - sale / market value dates

## Validation

- Confirmed the updated SQL runs successfully in BigQuery
- Confirmed the output table is created successfully:
  - `musa5090s26-team1.derived.current_assessments_model_training_data`
- Confirmed the restored older feature fields used in the updated query still exist in the current schema

## Reviewer notes

This PR is a schema-alignment fix, not a redesign of the modeling pipeline. The goal is to make Issue #9 valid again under the current repo structure while preserving as much of the original training-feature set as possible.