### PR TITLE
Align prediction training SQL with model training data

### DIFF
--- a/tasks/predict-current-assessments/Dockerfile
+++ b/tasks/predict-current-assessments/Dockerfile
@@ -6,5 +6,6 @@ COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
 COPY main.py .
+COPY sql ./sql
 
 CMD ["python", "main.py"]

--- a/tasks/predict-current-assessments/main.py
+++ b/tasks/predict-current-assessments/main.py
@@ -1,85 +1,14 @@
+from pathlib import Path
+
 from google.cloud import bigquery
 
 PROJECT_ID = "musa5090s26-team1"
 LOCATION = "us-east4"
+SQL_DIR = Path(__file__).parent / "sql"
 
-TRAIN_SQL = """
-CREATE OR REPLACE MODEL `musa5090s26-team1.derived.sale_price_boosted_tree_v2`
-OPTIONS(
-  model_type = 'BOOSTED_TREE_REGRESSOR',
-  input_label_cols = ['log_sale_price']
-) AS
-SELECT
-  log_sale_price,
-  total_livable_area,
-  taxable_building,
-  taxable_land,
-  quality_grade,
-  interior_condition_rev,
-  exterior_condition_rev,
-  garage_spaces,
-  assessment_year,
-  year_built_int
-FROM `musa5090s26-team1.derived.current_assessments_model_training_data`
-WHERE log_sale_price IS NOT NULL
-"""
 
-BUILD_PREDICTION_INPUT_SQL = """
-CREATE OR REPLACE TABLE `musa5090s26-team1.derived.current_assessments_prediction_input` AS
-SELECT
-  property_id,
-  SAFE_CAST(total_livable_area AS FLOAT64) AS total_livable_area,
-  SAFE_CAST(taxable_building AS FLOAT64) AS taxable_building,
-  SAFE_CAST(taxable_land AS FLOAT64) AS taxable_land,
-  quality_grade,
-  SAFE_CAST(garage_spaces AS FLOAT64) AS garage_spaces,
-  EXTRACT(YEAR FROM SAFE.PARSE_DATE('%Y-%m-%d', assessment_date)) AS assessment_year,
-  SAFE_CAST(year_built AS INT64) AS year_built_int,
-  CASE
-    WHEN SAFE_CAST(interior_condition AS INT64) IS NOT NULL
-      THEN 8 - SAFE_CAST(interior_condition AS INT64)
-    ELSE NULL
-  END AS interior_condition_rev,
-  CASE
-    WHEN SAFE_CAST(exterior_condition AS INT64) IS NOT NULL
-      THEN 8 - SAFE_CAST(exterior_condition AS INT64)
-    ELSE NULL
-  END AS exterior_condition_rev
-FROM `musa5090s26-team1.core.opa_properties`
-WHERE property_id IS NOT NULL
-  AND category_code_description IN (
-    'SINGLE FAMILY',
-    'MULTI FAMILY',
-    'APARTMENTS > 4 UNITS',
-    'VACANT LAND - RESIDENTIAL',
-    'GARAGE - RESIDENTIAL'
-  )
-"""
-
-PREDICT_SQL = """
-CREATE OR REPLACE TABLE `musa5090s26-team1.derived.current_assessments` AS
-SELECT
-  property_id,
-  EXP(predicted_log_sale_price) AS predicted_value,
-  CURRENT_TIMESTAMP() AS predicted_at
-FROM ML.PREDICT(
-  MODEL `musa5090s26-team1.derived.sale_price_boosted_tree_v2`,
-  (
-    SELECT
-      property_id,
-      total_livable_area,
-      taxable_building,
-      taxable_land,
-      quality_grade,
-      interior_condition_rev,
-      exterior_condition_rev,
-      garage_spaces,
-      assessment_year,
-      year_built_int
-    FROM `musa5090s26-team1.derived.current_assessments_prediction_input`
-  )
-)
-"""
+def read_sql(filename: str) -> str:
+    return (SQL_DIR / filename).read_text(encoding="utf-8")
 
 
 def run_query(client: bigquery.Client, sql: str, label: str) -> None:
@@ -92,9 +21,9 @@ def run_query(client: bigquery.Client, sql: str, label: str) -> None:
 def main():
     client = bigquery.Client(project=PROJECT_ID)
 
-    run_query(client, TRAIN_SQL, "train model")
-    run_query(client, BUILD_PREDICTION_INPUT_SQL, "build prediction input")
-    run_query(client, PREDICT_SQL, "write current assessments")
+    run_query(client, read_sql("train_model.sql"), "train model")
+    run_query(client, read_sql("build_prediction_input.sql"), "build prediction input")
+    run_query(client, read_sql("predict_current_assessments.sql"), "write current assessments")
 
     print("All steps completed successfully.")
 

--- a/tasks/predict-current-assessments/sql/build_prediction_input.sql
+++ b/tasks/predict-current-assessments/sql/build_prediction_input.sql
@@ -1,29 +1,30 @@
 CREATE OR REPLACE TABLE `musa5090s26-team1.derived.current_assessments_prediction_input` AS
 SELECT
-  property_id,
-  SAFE_CAST(total_livable_area AS FLOAT64) AS total_livable_area,
-  SAFE_CAST(taxable_building AS FLOAT64) AS taxable_building,
-  SAFE_CAST(taxable_land AS FLOAT64) AS taxable_land,
-  quality_grade,
-  SAFE_CAST(garage_spaces AS FLOAT64) AS garage_spaces,
-  EXTRACT(YEAR FROM SAFE.PARSE_DATE('%Y-%m-%d', assessment_date)) AS assessment_year,
-  SAFE_CAST(year_built AS INT64) AS year_built_int,
-  CASE
-    WHEN SAFE_CAST(interior_condition AS INT64) IS NOT NULL
-      THEN 8 - SAFE_CAST(interior_condition AS INT64)
-    ELSE NULL
-  END AS interior_condition_rev,
-  CASE
-    WHEN SAFE_CAST(exterior_condition AS INT64) IS NOT NULL
-      THEN 8 - SAFE_CAST(exterior_condition AS INT64)
-    ELSE NULL
-  END AS exterior_condition_rev
+    property_id,
+    SAFE_CAST(total_livable_area AS FLOAT64) AS total_livable_area,
+    SAFE_CAST(taxable_building AS FLOAT64) AS taxable_building,
+    SAFE_CAST(taxable_land AS FLOAT64) AS taxable_land,
+    quality_grade,
+    SAFE_CAST(garage_spaces AS FLOAT64) AS garage_spaces,
+    EXTRACT(YEAR FROM SAFE.PARSE_DATE('%Y-%m-%d', assessment_date)) AS assessment_year,
+    SAFE_CAST(year_built AS INT64) AS year_built_int,
+    CASE
+        WHEN SAFE_CAST(interior_condition AS INT64) IS NOT NULL
+            THEN 8 - SAFE_CAST(interior_condition AS INT64)
+        ELSE NULL
+    END AS interior_condition_rev,
+    CASE
+        WHEN SAFE_CAST(exterior_condition AS INT64) IS NOT NULL
+            THEN 8 - SAFE_CAST(exterior_condition AS INT64)
+        ELSE NULL
+    END AS exterior_condition_rev
 FROM `musa5090s26-team1.core.opa_properties`
-WHERE property_id IS NOT NULL
-  AND category_code_description IN (
-    'SINGLE FAMILY',
-    'MULTI FAMILY',
-    'APARTMENTS > 4 UNITS',
-    'VACANT LAND - RESIDENTIAL',
-    'GARAGE - RESIDENTIAL'
-  )
+WHERE
+    property_id IS NOT NULL
+    AND category_code_description IN (
+        'SINGLE FAMILY',
+        'MULTI FAMILY',
+        'APARTMENTS > 4 UNITS',
+        'VACANT LAND - RESIDENTIAL',
+        'GARAGE - RESIDENTIAL'
+    )

--- a/tasks/predict-current-assessments/sql/build_prediction_input.sql
+++ b/tasks/predict-current-assessments/sql/build_prediction_input.sql
@@ -1,0 +1,29 @@
+CREATE OR REPLACE TABLE `musa5090s26-team1.derived.current_assessments_prediction_input` AS
+SELECT
+  property_id,
+  SAFE_CAST(total_livable_area AS FLOAT64) AS total_livable_area,
+  SAFE_CAST(taxable_building AS FLOAT64) AS taxable_building,
+  SAFE_CAST(taxable_land AS FLOAT64) AS taxable_land,
+  quality_grade,
+  SAFE_CAST(garage_spaces AS FLOAT64) AS garage_spaces,
+  EXTRACT(YEAR FROM SAFE.PARSE_DATE('%Y-%m-%d', assessment_date)) AS assessment_year,
+  SAFE_CAST(year_built AS INT64) AS year_built_int,
+  CASE
+    WHEN SAFE_CAST(interior_condition AS INT64) IS NOT NULL
+      THEN 8 - SAFE_CAST(interior_condition AS INT64)
+    ELSE NULL
+  END AS interior_condition_rev,
+  CASE
+    WHEN SAFE_CAST(exterior_condition AS INT64) IS NOT NULL
+      THEN 8 - SAFE_CAST(exterior_condition AS INT64)
+    ELSE NULL
+  END AS exterior_condition_rev
+FROM `musa5090s26-team1.core.opa_properties`
+WHERE property_id IS NOT NULL
+  AND category_code_description IN (
+    'SINGLE FAMILY',
+    'MULTI FAMILY',
+    'APARTMENTS > 4 UNITS',
+    'VACANT LAND - RESIDENTIAL',
+    'GARAGE - RESIDENTIAL'
+  )

--- a/tasks/predict-current-assessments/sql/predict_current_assessments.sql
+++ b/tasks/predict-current-assessments/sql/predict_current_assessments.sql
@@ -1,0 +1,22 @@
+CREATE OR REPLACE TABLE `musa5090s26-team1.derived.current_assessments` AS
+SELECT
+  property_id,
+  EXP(predicted_log_sale_price) AS predicted_value,
+  CURRENT_TIMESTAMP() AS predicted_at
+FROM ML.PREDICT(
+  MODEL `musa5090s26-team1.derived.sale_price_boosted_tree_v2`,
+  (
+    SELECT
+      property_id,
+      total_livable_area,
+      taxable_building,
+      taxable_land,
+      quality_grade,
+      interior_condition_rev,
+      exterior_condition_rev,
+      garage_spaces,
+      assessment_year,
+      year_built_int
+    FROM `musa5090s26-team1.derived.current_assessments_prediction_input`
+  )
+)

--- a/tasks/predict-current-assessments/sql/predict_current_assessments.sql
+++ b/tasks/predict-current-assessments/sql/predict_current_assessments.sql
@@ -1,22 +1,22 @@
 CREATE OR REPLACE TABLE `musa5090s26-team1.derived.current_assessments` AS
 SELECT
-  property_id,
-  EXP(predicted_log_sale_price) AS predicted_value,
-  CURRENT_TIMESTAMP() AS predicted_at
-FROM ML.PREDICT(
-  MODEL `musa5090s26-team1.derived.sale_price_boosted_tree_v2`,
-  (
-    SELECT
-      property_id,
-      total_livable_area,
-      taxable_building,
-      taxable_land,
-      quality_grade,
-      interior_condition_rev,
-      exterior_condition_rev,
-      garage_spaces,
-      assessment_year,
-      year_built_int
-    FROM `musa5090s26-team1.derived.current_assessments_prediction_input`
-  )
+    property_id,
+    EXP(predicted_log_sale_price) AS predicted_value,
+    CURRENT_TIMESTAMP() AS predicted_at
+FROM ML.predict (
+    MODEL `musa5090s26-team1.derived.sale_price_boosted_tree_v2`,
+    (
+        SELECT
+            property_id,
+            total_livable_area,
+            taxable_building,
+            taxable_land,
+            quality_grade,
+            interior_condition_rev,
+            exterior_condition_rev,
+            garage_spaces,
+            assessment_year,
+            year_built_int
+        FROM `musa5090s26-team1.derived.current_assessments_prediction_input`
+    )
 )

--- a/tasks/predict-current-assessments/sql/train_model.sql
+++ b/tasks/predict-current-assessments/sql/train_model.sql
@@ -1,29 +1,29 @@
 CREATE OR REPLACE MODEL `musa5090s26-team1.derived.sale_price_boosted_tree_v2`
-OPTIONS(
-  model_type = 'BOOSTED_TREE_REGRESSOR',
-  input_label_cols = ['log_sale_price']
+OPTIONS (
+    model_type = 'BOOSTED_TREE_REGRESSOR',
+    input_label_cols = ['log_sale_price']
 ) AS
 SELECT
-  LOG(SAFE_CAST(target_sale_price AS FLOAT64)) AS log_sale_price,
-  SAFE_CAST(total_livable_area AS FLOAT64) AS total_livable_area,
-  SAFE_CAST(taxable_building AS FLOAT64) AS taxable_building,
-  SAFE_CAST(taxable_land AS FLOAT64) AS taxable_land,
-  quality_grade,
-  CASE
-    WHEN SAFE_CAST(interior_condition AS INT64) IS NOT NULL
-      THEN 8 - SAFE_CAST(interior_condition AS INT64)
-    ELSE NULL
-  END AS interior_condition_rev,
-  CASE
-    WHEN SAFE_CAST(exterior_condition AS INT64) IS NOT NULL
-      THEN 8 - SAFE_CAST(exterior_condition AS INT64)
-    ELSE NULL
-  END AS exterior_condition_rev,
-  SAFE_CAST(garage_spaces AS FLOAT64) AS garage_spaces,
-  SAFE_CAST(assessment_year AS INT64) AS assessment_year,
-  SAFE_CAST(year_built AS INT64) AS year_built_int
+    LOG(SAFE_CAST(target_sale_price AS FLOAT64)) AS log_sale_price,
+    SAFE_CAST(total_livable_area AS FLOAT64) AS total_livable_area,
+    SAFE_CAST(taxable_building AS FLOAT64) AS taxable_building,
+    SAFE_CAST(taxable_land AS FLOAT64) AS taxable_land,
+    quality_grade,
+    CASE
+        WHEN SAFE_CAST(interior_condition AS INT64) IS NOT NULL
+            THEN 8 - SAFE_CAST(interior_condition AS INT64)
+        ELSE NULL
+    END AS interior_condition_rev,
+    CASE
+        WHEN SAFE_CAST(exterior_condition AS INT64) IS NOT NULL
+            THEN 8 - SAFE_CAST(exterior_condition AS INT64)
+        ELSE NULL
+    END AS exterior_condition_rev,
+    SAFE_CAST(garage_spaces AS FLOAT64) AS garage_spaces,
+    SAFE_CAST(assessment_year AS INT64) AS assessment_year,
+    SAFE_CAST(year_built AS INT64) AS year_built_int
 FROM `musa5090s26-team1.derived.current_assessments_model_training_data`
 WHERE
-  SAFE_CAST(target_sale_price AS FLOAT64) IS NOT NULL
-  AND SAFE_CAST(target_sale_price AS FLOAT64) > 1000
-  AND SAFE_CAST(target_sale_price AS FLOAT64) < 5000000
+    SAFE_CAST(target_sale_price AS FLOAT64) IS NOT NULL
+    AND SAFE_CAST(target_sale_price AS FLOAT64) > 1000
+    AND SAFE_CAST(target_sale_price AS FLOAT64) < 5000000

--- a/tasks/predict-current-assessments/sql/train_model.sql
+++ b/tasks/predict-current-assessments/sql/train_model.sql
@@ -1,0 +1,29 @@
+CREATE OR REPLACE MODEL `musa5090s26-team1.derived.sale_price_boosted_tree_v2`
+OPTIONS(
+  model_type = 'BOOSTED_TREE_REGRESSOR',
+  input_label_cols = ['log_sale_price']
+) AS
+SELECT
+  LOG(SAFE_CAST(target_sale_price AS FLOAT64)) AS log_sale_price,
+  SAFE_CAST(total_livable_area AS FLOAT64) AS total_livable_area,
+  SAFE_CAST(taxable_building AS FLOAT64) AS taxable_building,
+  SAFE_CAST(taxable_land AS FLOAT64) AS taxable_land,
+  quality_grade,
+  CASE
+    WHEN SAFE_CAST(interior_condition AS INT64) IS NOT NULL
+      THEN 8 - SAFE_CAST(interior_condition AS INT64)
+    ELSE NULL
+  END AS interior_condition_rev,
+  CASE
+    WHEN SAFE_CAST(exterior_condition AS INT64) IS NOT NULL
+      THEN 8 - SAFE_CAST(exterior_condition AS INT64)
+    ELSE NULL
+  END AS exterior_condition_rev,
+  SAFE_CAST(garage_spaces AS FLOAT64) AS garage_spaces,
+  SAFE_CAST(assessment_year AS INT64) AS assessment_year,
+  SAFE_CAST(year_built AS INT64) AS year_built_int
+FROM `musa5090s26-team1.derived.current_assessments_model_training_data`
+WHERE
+  SAFE_CAST(target_sale_price AS FLOAT64) IS NOT NULL
+  AND SAFE_CAST(target_sale_price AS FLOAT64) > 1000
+  AND SAFE_CAST(target_sale_price AS FLOAT64) < 5000000


### PR DESCRIPTION
## Summary

This PR updates the `predict-current-assessments` Cloud Run job so its training query is compatible with the current `derived.current_assessments_model_training_data` table produced by issue #9.

The issue #9 training table is now a wide training table with raw fields such as `target_sale_price`, `interior_condition`, `exterior_condition`, and `year_built`. Previously, the prediction job expected model-ready fields such as `log_sale_price`, `interior_condition_rev`, `exterior_condition_rev`, and `year_built_int` to already exist in that table.

This PR moves that model feature engineering into the prediction job’s training SQL.

## Changes

- Refactored inline SQL strings out of `main.py` into separate SQL files:
  - `sql/train_model.sql`
  - `sql/build_prediction_input.sql`
  - `sql/predict_current_assessments.sql`
- Updated `main.py` to read and execute those SQL files in the same order as before:
  1. train model
  2. build prediction input
  3. write current assessments
- Updated `train_model.sql` to compute model-ready fields from the issue #9 wide training table:
  - `LOG(SAFE_CAST(target_sale_price AS FLOAT64)) AS log_sale_price`
  - reversed interior/exterior condition fields
  - `SAFE_CAST(year_built AS INT64) AS year_built_int`
- Updated the Dockerfile to copy the `sql/` directory into the job container.

## What stays the same

- The Cloud Run job still runs the same three logical steps:
  - train model
  - build prediction input
  - write current assessments
- The model name remains:
  - `musa5090s26-team1.derived.sale_price_boosted_tree_v2`
- The final output table contract remains unchanged:
  - `derived.current_assessments`
  - fields: `property_id`, `predicted_value`, `predicted_at`
- No frontend files or workflow files are modified.

## Why this is needed

After issue #9, `derived.current_assessments_model_training_data` is no longer expected to be a model-ready table. It is a wider training table with raw training fields. This PR makes issue #12 responsible for model feature engineering during training, which keeps the boundary clearer:

- issue #9: produces the wide training data table
- issue #12: trains the model, builds prediction input, and writes current predictions

## Testing

Suggested checks after merge/deploy:

```bash
cd tasks/predict-current-assessments

gcloud run jobs deploy predict-current-assessments \
  --source . \
  --region us-east4 \
  --project musa5090s26-team1

gcloud run jobs execute predict-current-assessments \
  --region us-east4 \
  --project musa5090s26-team1 \
  --wait