### PR TITLE
Combine property lookup widget with assessment distribution chart

### DIFF
--- a/ui/widget/index.html
+++ b/ui/widget/index.html
@@ -1,121 +1,120 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Historical Assessment Value Widget</title>
-    <link rel="stylesheet" href="https://unpkg.com/leaflet/dist/leaflet.css" />
-    <link rel="stylesheet" href="./style.css" />
-  </head>
-  <script src="https://unpkg.com/leaflet/dist/leaflet.js"></script>
-  <script src="./main.js"></script>
-  <body>
-    <main class="widget-page">
-      <header class="widget-header">
-        <p class="eyebrow">Property assessments</p>
-        <h1>Historical Assessment Value</h1>
-        <p class="intro">
-          View historical assessment values for a selected property using its
-          OPA ID.
-        </p>
-      </header>
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Property Assessment Viewer</title>
 
-      <section class="lookup-panel" aria-label="Property lookup">
-        <label for="opaIdInput" class="input-label">OPA ID</label>
-        <div class="lookup-row">
-          <input
-            id="opaIdInput"
-            type="text"
-            inputmode="numeric"
-            placeholder="Enter OPA ID (e.g., 123456700)"
-            aria-describedby="opaIdHelp"
-          />
-          <button id="searchBtn" type="button">Look up property</button>
+  <link rel="stylesheet" href="https://unpkg.com/leaflet/dist/leaflet.css" />
+  <link rel="stylesheet" href="./style.css" />
+</head>
+<body>
+  <main class="widget-page">
+    <header class="widget-header">
+      <p class="eyebrow">Philadelphia CAMA</p>
+      <h1>Property Assessment Viewer</h1>
+      <p class="intro">
+        Look up a sample property assessment history and compare it with
+        citywide assessment distributions.
+      </p>
+    </header>
+
+    <section class="lookup-panel" aria-label="Property lookup">
+      <label for="opaIdInput" class="input-label">OPA ID</label>
+      <div class="lookup-row">
+        <input
+          id="opaIdInput"
+          type="text"
+          inputmode="numeric"
+          placeholder="Enter sample OPA ID (e.g., 502244720)"
+          aria-describedby="opaIdHelp lookupMessage"
+        />
+        <button id="searchBtn" type="button">Look up property</button>
+      </div>
+      <p id="opaIdHelp" class="helper-text">
+        This static demo uses sample property data. Try OPA ID 502244720.
+      </p>
+      <p id="lookupMessage" class="lookup-message" role="status" aria-live="polite"></p>
+    </section>
+
+    <section class="main-grid">
+      <article class="card summary-card" aria-labelledby="summary-heading">
+        <h2 id="summary-heading">Property summary</h2>
+        <dl class="summary-list">
+          <div class="summary-row">
+            <dt>OPA ID</dt>
+            <dd id="opaIdText">-</dd>
+          </div>
+          <div class="summary-row">
+            <dt>Address</dt>
+            <dd id="addressText">-</dd>
+          </div>
+          <div class="summary-row">
+            <dt>Current assessment</dt>
+            <dd id="currentValueText">-</dd>
+          </div>
+          <div class="summary-row">
+            <dt>Tax year</dt>
+            <dd id="taxYearText">-</dd>
+          </div>
+          <div class="summary-row">
+            <dt>Neighborhood</dt>
+            <dd id="neighborhoodText">-</dd>
+          </div>
+        </dl>
+      </article>
+
+      <article class="card map-card" aria-labelledby="map-heading">
+        <div class="card-header">
+          <h2 id="map-heading">Map</h2>
+          <p>Property location and surrounding context</p>
         </div>
-        <p id="opaIdHelp" class="helper-text">
-          Enter a 9–10 digit OPA identifier to load property assessment history.
-        </p>
-      </section>
+        <div id="map"></div>
+      </article>
+    </section>
 
-      <section class="content-grid">
-        <article class="card summary-card" aria-labelledby="summary-heading">
-          <h2 id="summary-heading">Property summary</h2>
-          <dl class="summary-list">
-            <div class="summary-row">
-              <dt>OPA ID</dt>
-              <dd id="opaIdText">123456700</dd>
-            </div>
-            <div class="summary-row">
-              <dt>Address</dt>
-              <dd id="addressText">123 Market St</dd>
-            </div>
-            <div class="summary-row">
-              <dt>Current assessment</dt>
-              <dd id="currentValueText">$320,000</dd>
-            </div>
-            <div class="summary-row">
-              <dt>Tax year</dt>
-              <dd id="taxYearText">2025</dd>
-            </div>
-            <div class="summary-row">
-              <dt>Neighborhood</dt>
-              <dd id="neighborhoodText">Center City</dd>
-            </div>
-          </dl>
-        </article>
+    <section class="bottom-grid">
+      <article class="card history-card" aria-labelledby="history-heading">
+        <div class="card-header">
+          <h2 id="history-heading">Assessment history</h2>
+          <p>Historical assessed values by tax year for the selected sample property</p>
+        </div>
+        <div id="assessmentHistoryChart" class="history-chart" aria-live="polite"></div>
+      </article>
 
-        <article class="card map-card" aria-labelledby="map-heading">
-          <div class="card-header">
-            <h2 id="map-heading">Map</h2>
-            <p>Property location and surrounding context</p>
-          </div>
-          <div id="map"></div>
-        </article>
-      </section>
-
-      <section class="bottom-grid">
-        <article class="card trend-card" aria-labelledby="trend-heading">
-          <div class="card-header">
-            <h2 id="trend-heading">Assessment history</h2>
-            <p>Historical assessed values by tax year</p>
-          </div>
-          <div class="trend-placeholder" aria-hidden="true">
-            <div class="bar-group">
-              <div class="bar" style="height: 38%"></div>
-              <span>2021</span>
-            </div>
-            <div class="bar-group">
-              <div class="bar" style="height: 48%"></div>
-              <span>2022</span>
-            </div>
-            <div class="bar-group">
-              <div class="bar" style="height: 58%"></div>
-              <span>2023</span>
-            </div>
-            <div class="bar-group">
-              <div class="bar" style="height: 70%"></div>
-              <span>2024</span>
-            </div>
-            <div class="bar-group">
-              <div class="bar" style="height: 82%"></div>
-              <span>2025</span>
-            </div>
-          </div>
-        </article>
-
-        <article class="card notes-card" aria-labelledby="notes-heading">
-          <div class="card-header">
-            <h2 id="notes-heading">Notes</h2>
-            <p>Placeholder space for assessment context or methodology</p>
-          </div>
-          <p class="notes-text">
-            This area can be used later for explanatory text, metadata, or
-            links to assessment records.
+      <article class="card distribution-card" aria-labelledby="distribution-heading">
+        <div class="card-header">
+          <h2 id="distribution-heading">Citywide assessment distribution</h2>
+          <p id="latest-assessment-chart-helper">
+            Loading citywide assessment distribution from the public data asset.
           </p>
-        </article>
-      </section>
-    </main>
+        </div>
+        <div
+          id="latest-assessment-chart-error"
+          class="chart-error"
+          role="status"
+          aria-live="polite"
+        ></div>
+        <div id="latest-assessment-chart"></div>
+      </article>
+    </section>
 
-    <script src="./main.js"></script>
-  </body>
+    <section class="card notes-card" aria-labelledby="notes-heading">
+      <div class="card-header">
+        <h2 id="notes-heading">Notes</h2>
+        <p>How this demo connects to the cloud data pipeline</p>
+      </div>
+      <p class="notes-text">
+        The property lookup, map, and assessment history use static sample data
+        for this browser-only demo. The citywide distribution chart loads from
+        the public Cloud Storage JSON file generated by the data pipeline:
+        <code>configs/tax_year_assessment_bins.json</code>.
+      </p>
+    </section>
+  </main>
+
+  <script src="https://unpkg.com/leaflet/dist/leaflet.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/apexcharts"></script>
+  <script src="./main.js"></script>
+</body>
 </html>

--- a/ui/widget/main.js
+++ b/ui/widget/main.js
@@ -1,4 +1,4 @@
-const data = [
+const SAMPLE_PROPERTIES = [
   {
     propertyId: "502244720",
     address: "Sample property record",
@@ -22,8 +22,12 @@ const data = [
   },
 ];
 
-let map = null;
-let marker = null;
+const TAX_YEAR_ASSESSMENT_BINS_URL =
+  "https://storage.googleapis.com/musa5090s26-team1-public/configs/tax_year_assessment_bins.json";
+const MAIN_DISPLAY_MAX = 2500000;
+const MAIN_DISPLAY_BIN_SIZE = 100000;
+const OVERFLOW_LABEL = ">$2.5M";
+const RANGE_SEPARATOR = "-";
 
 const DEFAULT_VIEW = {
   lat: 39.9526,
@@ -31,8 +35,30 @@ const DEFAULT_VIEW = {
   zoom: 12,
 };
 
+let map = null;
+let marker = null;
+let assessmentHistoryChart = null;
+let latestAssessmentChart = null;
+
 function formatMoney(value) {
-  return `$${Number(value).toLocaleString()}`;
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    maximumFractionDigits: 0,
+  }).format(value);
+}
+
+function formatCompactCurrency(value) {
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    notation: "compact",
+    maximumFractionDigits: 1,
+  }).format(value);
+}
+
+function formatNumber(value) {
+  return new Intl.NumberFormat("en-US").format(value);
 }
 
 function initializeMap() {
@@ -46,8 +72,14 @@ function initializeMap() {
   }).addTo(map);
 }
 
+function setLookupMessage(message = "") {
+  document.getElementById("lookupMessage").textContent = message;
+}
+
 function updateMap(property) {
-  if (!map) return;
+  if (!map) {
+    return;
+  }
 
   map.setView([property.lat, property.lng], 15);
 
@@ -61,91 +93,373 @@ function updateMap(property) {
     .openPopup();
 }
 
-function resetSummary() {
-  document.getElementById("opaIdText").textContent = "—";
-  document.getElementById("addressText").textContent = "—";
-  document.getElementById("currentValueText").textContent = "—";
-  document.getElementById("taxYearText").textContent = "—";
-  document.getElementById("neighborhoodText").textContent = "—";
-}
-
-function resetTrend() {
-  const trendContainer = document.querySelector(".trend-placeholder");
-  trendContainer.innerHTML =
-    '<p class="empty-message">Assessment history will appear after lookup.</p>';
-}
-
-function resetView() {
-  resetSummary();
-  resetTrend();
-
-  if (map) {
-    map.setView([DEFAULT_VIEW.lat, DEFAULT_VIEW.lng], DEFAULT_VIEW.zoom);
-
-    if (marker) {
-      map.removeLayer(marker);
-      marker = null;
-    }
-  }
-}
-
-function renderTrend(property) {
-  const trendContainer = document.querySelector(".trend-placeholder");
-  trendContainer.innerHTML = "";
-
-  const maxValue = Math.max(
-    ...property.history.map((item) => Number(item.marketValue)),
-  );
-
-  property.history.forEach((item) => {
-    const group = document.createElement("div");
-    group.className = "bar-group";
-
-    const bar = document.createElement("div");
-    bar.className = "bar";
-    bar.style.height = `${(Number(item.marketValue) / maxValue) * 100}%`;
-
-    const label = document.createElement("span");
-    label.textContent = item.year;
-
-    group.appendChild(bar);
-    group.appendChild(label);
-    trendContainer.appendChild(group);
-  });
-}
-
 function renderSummary(property) {
-  document.getElementById("opaIdText").textContent = property.propertyId;
-  document.getElementById("addressText").textContent = property.address || "N/A";
-  document.getElementById("neighborhoodText").textContent =
-    property.neighborhood || "N/A";
-
   const latest = property.history[property.history.length - 1];
+
+  document.getElementById("opaIdText").textContent = property.propertyId;
+  document.getElementById("addressText").textContent = property.address;
   document.getElementById("currentValueText").textContent = formatMoney(
     latest.marketValue,
   );
   document.getElementById("taxYearText").textContent = latest.year;
+  document.getElementById("neighborhoodText").textContent = property.neighborhood;
+}
+
+function renderAssessmentHistory(property) {
+  const chartElement = document.getElementById("assessmentHistoryChart");
+
+  if (assessmentHistoryChart) {
+    assessmentHistoryChart.destroy();
+  }
+
+  assessmentHistoryChart = new window.ApexCharts(chartElement, {
+    chart: {
+      type: "bar",
+      height: 300,
+      width: "100%",
+      parentHeightOffset: 0,
+      toolbar: {
+        show: false,
+      },
+    },
+    series: [
+      {
+        name: "Assessed value",
+        data: property.history.map((item) => Number(item.marketValue)),
+      },
+    ],
+    colors: ["#0d3b66"],
+    fill: {
+      type: "solid",
+      opacity: 1,
+    },
+    plotOptions: {
+      bar: {
+        borderRadius: 4,
+        columnWidth: "58%",
+      },
+    },
+    dataLabels: {
+      enabled: false,
+    },
+    grid: {
+      borderColor: "#e5e7eb",
+      padding: {
+        left: 10,
+        right: 12,
+        top: 6,
+        bottom: 0,
+      },
+      strokeDashArray: 4,
+    },
+    xaxis: {
+      categories: property.history.map((item) => item.year),
+      title: {
+        text: "Tax year",
+      },
+      labels: {
+        rotate: -45,
+        rotateAlways: false,
+        trim: false,
+        hideOverlappingLabels: false,
+        style: {
+          fontSize: "11px",
+        },
+      },
+    },
+    yaxis: {
+      title: {
+        text: "Assessed value",
+      },
+      labels: {
+        minWidth: 72,
+        formatter: (value) => formatCompactCurrency(value),
+      },
+    },
+    tooltip: {
+      x: {
+        formatter: (_value, { dataPointIndex }) =>
+          `Tax year ${property.history[dataPointIndex].year}`,
+      },
+      y: {
+        formatter: (value) => formatMoney(value),
+        title: {
+          formatter: () => "Assessed value:",
+        },
+      },
+    },
+    responsive: [
+      {
+        breakpoint: 760,
+        options: {
+          chart: {
+            height: 320,
+          },
+          plotOptions: {
+            bar: {
+              columnWidth: "66%",
+            },
+          },
+        },
+      },
+    ],
+  });
+
+  assessmentHistoryChart.render();
 }
 
 function renderProperty(property) {
   renderSummary(property);
-  renderTrend(property);
+  renderAssessmentHistory(property);
   updateMap(property);
 }
 
-document.addEventListener("DOMContentLoaded", () => {
-  initializeMap();
-  resetView();
+function lookupProperty() {
+  const opaId = document.getElementById("opaIdInput").value.trim();
+  const property = SAMPLE_PROPERTIES.find((item) => item.propertyId === opaId);
 
-  document.getElementById("searchBtn").addEventListener("click", () => {
-    const opaId = document.getElementById("opaIdInput").value.trim();
-    const match = data.find((item) => item.propertyId === opaId);
+  if (!property) {
+    setLookupMessage("OPA ID not found in sample data. Try 502244720.");
+    return;
+  }
 
-    if (match) {
-      renderProperty(match);
+  setLookupMessage("");
+  renderProperty(property);
+}
+
+function setChartError(message = "") {
+  const errorElement = document.getElementById("latest-assessment-chart-error");
+  errorElement.textContent = message;
+  errorElement.style.display = message ? "block" : "none";
+}
+
+function setChartHelperText(message) {
+  document.getElementById("latest-assessment-chart-helper").textContent = message;
+}
+
+function destroyLatestAssessmentChart() {
+  if (latestAssessmentChart) {
+    latestAssessmentChart.destroy();
+    latestAssessmentChart = null;
+  }
+}
+
+function buildDisplayBins(rows) {
+  const bins = [];
+  let lowerBound = 0;
+
+  while (lowerBound < MAIN_DISPLAY_MAX) {
+    bins.push({
+      lowerBound,
+      upperBound: lowerBound + MAIN_DISPLAY_BIN_SIZE,
+      propertyCount: 0,
+      label: "",
+      tooltipLabel: "",
+      isOverflow: false,
+    });
+    lowerBound += MAIN_DISPLAY_BIN_SIZE;
+  }
+
+  bins.push({
+    lowerBound: MAIN_DISPLAY_MAX,
+    upperBound: null,
+    propertyCount: 0,
+    label: OVERFLOW_LABEL,
+    tooltipLabel: `>${formatMoney(MAIN_DISPLAY_MAX)}`,
+    isOverflow: true,
+  });
+
+  for (const row of rows) {
+    if (row.lowerBound >= MAIN_DISPLAY_MAX || row.upperBound > MAIN_DISPLAY_MAX) {
+      bins[bins.length - 1].propertyCount += row.propertyCount;
+      continue;
+    }
+
+    const index = Math.floor(row.lowerBound / MAIN_DISPLAY_BIN_SIZE);
+    if (bins[index]) {
+      bins[index].propertyCount += row.propertyCount;
+    }
+  }
+
+  for (const bin of bins) {
+    if (bin.isOverflow) {
+      continue;
+    }
+
+    bin.tooltipLabel = `${formatMoney(bin.lowerBound)} ${RANGE_SEPARATOR} ${formatMoney(bin.upperBound - 1)}`;
+
+    if (bin.lowerBound === 0) {
+      bin.label = "$0";
+    } else if (bin.lowerBound % 500000 === 0) {
+      bin.label = formatCompactCurrency(bin.lowerBound);
     } else {
-      alert("OPA ID not found in sample data.");
-      resetView();
+      bin.label = "";
+    }
+  }
+
+  return bins;
+}
+
+function renderLatestAssessmentChart(rows, latestTaxYear) {
+  const chartElement = document.getElementById("latest-assessment-chart");
+  const categories = rows.map((row) => row.label);
+  const seriesData = rows.map((row) => ({
+    x: row.label,
+    y: row.propertyCount,
+  }));
+
+  destroyLatestAssessmentChart();
+  setChartError("");
+  setChartHelperText(
+    `Latest tax year (${latestTaxYear}) distribution. Main range shown up to $2.5M; higher values grouped into an overflow bin.`,
+  );
+
+  latestAssessmentChart = new window.ApexCharts(chartElement, {
+    chart: {
+      type: "bar",
+      height: 340,
+      toolbar: {
+        show: false,
+      },
+      animations: {
+        easing: "easeinout",
+        speed: 350,
+      },
+    },
+    series: [
+      {
+        name: "Properties",
+        data: seriesData,
+      },
+    ],
+    colors: ["#0d3b66"],
+    plotOptions: {
+      bar: {
+        borderRadius: 4,
+        columnWidth: "86%",
+      },
+    },
+    dataLabels: {
+      enabled: false,
+    },
+    legend: {
+      show: false,
+    },
+    grid: {
+      borderColor: "#e5e7eb",
+      strokeDashArray: 4,
+    },
+    xaxis: {
+      categories,
+      tickPlacement: "between",
+      labels: {
+        rotate: 0,
+        trim: false,
+        hideOverlappingLabels: true,
+      },
+      title: {
+        text: "Assessed value range",
+      },
+    },
+    yaxis: {
+      title: {
+        text: "Property count",
+      },
+      labels: {
+        formatter: (value) => formatNumber(Math.round(value)),
+      },
+    },
+    tooltip: {
+      x: {
+        formatter: (_value, { dataPointIndex }) => rows[dataPointIndex].tooltipLabel,
+      },
+      y: {
+        formatter: (value) => `${formatNumber(value)} properties`,
+      },
+    },
+  });
+
+  latestAssessmentChart.render();
+}
+
+async function loadLatestAssessmentChart() {
+  try {
+    setChartError("");
+    setChartHelperText("Loading citywide assessment distribution...");
+
+    if (!window.ApexCharts) {
+      throw new Error("Assessment chart library failed to load.");
+    }
+
+    const response = await fetch(TAX_YEAR_ASSESSMENT_BINS_URL);
+    if (!response.ok) {
+      throw new Error(`Unable to load assessment chart data (${response.status}).`);
+    }
+
+    const payload = await response.json();
+    if (!Array.isArray(payload) || payload.length === 0) {
+      destroyLatestAssessmentChart();
+      setChartError("No assessment distribution data is available right now.");
+      return;
+    }
+
+    const taxYears = payload
+      .map((row) => Number(row.tax_year))
+      .filter((taxYear) => Number.isFinite(taxYear));
+
+    if (taxYears.length === 0) {
+      destroyLatestAssessmentChart();
+      setChartError("Assessment distribution data is missing tax year values.");
+      return;
+    }
+
+    const latestTaxYear = Math.max(...taxYears);
+    const latestRows = payload
+      .filter((row) => Number(row.tax_year) === latestTaxYear)
+      .map((row) => ({
+        lowerBound: Number(row.lower_bound),
+        upperBound: Number(row.upper_bound),
+        propertyCount: Number(row.property_count),
+      }))
+      .filter(
+        (row) =>
+          Number.isFinite(row.lowerBound) &&
+          Number.isFinite(row.upperBound) &&
+          Number.isFinite(row.propertyCount),
+      )
+      .sort((left, right) => left.lowerBound - right.lowerBound);
+
+    if (latestRows.length === 0) {
+      destroyLatestAssessmentChart();
+      setChartError(
+        `No assessment distribution bins were found for tax year ${latestTaxYear}.`,
+      );
+      return;
+    }
+
+    renderLatestAssessmentChart(buildDisplayBins(latestRows), latestTaxYear);
+  } catch (error) {
+    destroyLatestAssessmentChart();
+    setChartError(
+      error instanceof Error
+        ? error.message
+        : "Unable to load the latest assessment distribution chart.",
+    );
+  }
+}
+
+document.addEventListener("DOMContentLoaded", () => {
+  const sampleProperty = SAMPLE_PROPERTIES[0];
+
+  initializeMap();
+  renderProperty(sampleProperty);
+  loadLatestAssessmentChart();
+
+  document.getElementById("opaIdInput").value = sampleProperty.propertyId;
+  document.getElementById("searchBtn").addEventListener("click", lookupProperty);
+  document.getElementById("opaIdInput").addEventListener("keydown", (event) => {
+    if (event.key === "Enter") {
+      lookupProperty();
     }
   });
 });

--- a/ui/widget/style.css
+++ b/ui/widget/style.css
@@ -3,15 +3,18 @@
 }
 
 :root {
-  --bg: #f0f0f0;
+  --bg: #f0f2f5;
   --surface: #fff;
-  --border: #d9d9d9;
-  --text: #222;
-  --muted: #5c5c5c;
-  --heading: #0f0f0f;
+  --border: #d9dde5;
+  --text: #20242c;
+  --muted: #626b7a;
+  --heading: #111827;
   --accent: #0d3b66;
-  --accent-hover: #0a2f52;
-  --soft: #f7f7f7;
+  --accent-hover: #092f52;
+  --soft: #f7f8fa;
+  --error-bg: #fef2f2;
+  --error-border: #f1c7c7;
+  --error-text: #991b1b;
 }
 
 body {
@@ -22,7 +25,7 @@ body {
 }
 
 .widget-page {
-  max-width: 1200px;
+  max-width: 1280px;
   margin: 0 auto;
   padding: 24px;
 }
@@ -36,20 +39,20 @@ body {
   color: var(--accent);
   font-size: 0.95rem;
   font-weight: 700;
-  text-transform: uppercase;
   letter-spacing: 0.04em;
+  text-transform: uppercase;
 }
 
 .widget-header h1 {
   margin: 0 0 8px;
-  font-size: 2rem;
-  line-height: 1.15;
   color: var(--heading);
+  font-size: 2.2rem;
+  line-height: 1.15;
 }
 
 .intro {
+  max-width: 780px;
   margin: 0;
-  max-width: 700px;
   color: var(--muted);
   line-height: 1.5;
 }
@@ -58,12 +61,13 @@ body {
 .card {
   background: var(--surface);
   border: 1px solid var(--border);
-  border-radius: 6px;
+  border-radius: 14px;
+  box-shadow: 0 8px 24px rgb(15 23 42 / 6%);
 }
 
 .lookup-panel {
-  padding: 18px;
   margin-bottom: 20px;
+  padding: 18px;
 }
 
 .input-label {
@@ -74,60 +78,67 @@ body {
 
 .lookup-row {
   display: grid;
-  grid-template-columns: 1fr 180px;
+  grid-template-columns: 1fr 190px;
   gap: 12px;
 }
 
 .lookup-row input {
   width: 100%;
   padding: 12px 14px;
-  border: 1px solid #bfbfbf;
-  border-radius: 4px;
-  font-size: 1rem;
+  border: 1px solid #bfc7d3;
+  border-radius: 8px;
   background: #fff;
+  font-size: 1rem;
 }
 
 .lookup-row input:focus {
-  outline: 2px solid #a3c9f1;
-  outline-offset: 1px;
   border-color: var(--accent);
+  outline: 3px solid rgb(13 59 102 / 18%);
 }
 
 .lookup-row button {
+  padding: 12px 16px;
   border: none;
-  border-radius: 4px;
+  border-radius: 8px;
   background: var(--accent);
   color: #fff;
+  cursor: pointer;
   font-size: 1rem;
   font-weight: 700;
-  cursor: pointer;
-  padding: 12px 16px;
 }
 
 .lookup-row button:hover {
   background: var(--accent-hover);
 }
 
-.helper-text {
+.helper-text,
+.lookup-message {
   margin: 8px 0 0;
   color: var(--muted);
   font-size: 0.92rem;
 }
 
-.content-grid {
+.lookup-message:not(:empty) {
+  color: var(--error-text);
+  font-weight: 700;
+}
+
+.main-grid {
   display: grid;
-  grid-template-columns: 360px 1fr;
+  grid-template-columns: minmax(300px, 380px) 1fr;
   gap: 20px;
   margin-bottom: 20px;
 }
 
 .bottom-grid {
   display: grid;
-  grid-template-columns: 1.35fr 1fr;
+  grid-template-columns: minmax(0, 0.95fr) minmax(0, 1.4fr);
   gap: 20px;
+  margin-bottom: 20px;
 }
 
 .card {
+  min-width: 0;
   padding: 20px;
 }
 
@@ -137,8 +148,8 @@ body {
 
 .card h2 {
   margin: 0 0 6px;
-  font-size: 1.35rem;
   color: var(--heading);
+  font-size: 1.35rem;
 }
 
 .card-header p {
@@ -156,7 +167,7 @@ body {
   grid-template-columns: 140px 1fr;
   gap: 16px;
   padding: 12px 0;
-  border-bottom: 1px solid #ececec;
+  border-bottom: 1px solid #eceff3;
 }
 
 .summary-row:first-child {
@@ -175,72 +186,71 @@ body {
 
 .summary-row dd {
   margin: 0;
-  font-weight: 700;
   color: var(--text);
+  font-weight: 700;
   text-align: right;
 }
 
-
 #map {
   height: 400px;
-  border: 1px solid #d9d9d9;
-  border-radius: 4px;
   overflow: hidden;
-  background: #f7f7f7;
-}
-
-.empty-message {
-  min-height: 220px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  color: #666;
-  font-weight: 600;
-  text-align: center;
-}
-
-.trend-placeholder {
-  height: 280px;
-  padding: 18px 12px 32px;
-  border: 1px dashed #bfbfbf;
-  border-radius: 4px;
+  border: 1px solid #d9dde5;
+  border-radius: 10px;
   background: var(--soft);
-  display: flex;
-  align-items: flex-end;
-  gap: 14px;
 }
 
-.bar-group {
-  flex: 1;
-  height: 100%;
-  display: flex;
-  flex-direction: column;
-  justify-content: flex-end;
-  align-items: center;
-  gap: 8px;
+.history-card,
+.distribution-card {
+  min-width: 0;
+  overflow: hidden;
 }
 
-.bar {
+.history-chart {
   width: 100%;
-  max-width: 54px;
-  background: linear-gradient(180deg, #7aa6d1 0%, #0d3b66 100%);
-  border-radius: 4px 4px 0 0;
-  min-height: 24px;
+  min-height: 320px;
+  overflow: hidden;
 }
 
-.bar-group span {
-  font-size: 0.88rem;
-  color: var(--muted);
+.history-chart .apexcharts-canvas,
+#latest-assessment-chart .apexcharts-canvas {
+  max-width: 100%;
+}
+
+#latest-assessment-chart {
+  min-height: 340px;
+  padding: 8px 4px 0;
+}
+
+.chart-error {
+  display: none;
+  margin-bottom: 12px;
+  padding: 12px 14px;
+  border: 1px solid var(--error-border);
+  border-radius: 10px;
+  background: var(--error-bg);
+  color: var(--error-text);
+  font-size: 0.95rem;
+  line-height: 1.5;
+}
+
+.notes-card {
+  margin-bottom: 8px;
 }
 
 .notes-text {
   margin: 0;
   color: var(--text);
-  line-height: 1.6;
+  line-height: 1.65;
 }
 
-@media (width <= 900px) {
-  .content-grid,
+.notes-text code {
+  padding: 2px 5px;
+  border-radius: 4px;
+  background: #eef2f7;
+}
+
+@media (width <= 980px) {
+  .main-grid,
   .bottom-grid {
     grid-template-columns: 1fr;
   }
@@ -256,5 +266,13 @@ body {
 
   .summary-row dd {
     text-align: left;
+  }
+
+  #map {
+    height: 320px;
+  }
+
+  #latest-assessment-chart {
+    min-height: 300px;
   }
 }


### PR DESCRIPTION
This PR combines the newer OPA ID lookup widget with the earlier public-bucket-powered citywide assessment distribution chart. The lookup and property history remain static browser-only demo elements, while the distribution chart loads the pipeline-generated tax_year_assessment_bins.json from the public Cloud Storage bucket.