### PR TITLE
Add ZIP context assets and realtime frontend enhancements

### DIFF
--- a/tasks/data-pipeline/DEPLOY.md
+++ b/tasks/data-pipeline/DEPLOY.md
@@ -45,6 +45,7 @@ The workflow expects these HTTP Cloud Functions to exist in project
 - `export-current-assessment-bins`
 - `export-property-tile-info`
 - `export-map-style-metadata`
+- `export-zip-assessment-context`
 
 ## Required Cloud Run Jobs
 
@@ -202,6 +203,7 @@ GCS config outputs:
 - `gs://musa5090s26-team1-public/configs/current_assessment_bins.json`
 - `gs://musa5090s26-team1-public/configs/tax_year_assessment_bins.json`
 - `gs://musa5090s26-team1-public/configs/map_style_metadata.json`
+- `gs://musa5090s26-team1-public/configs/zip_assessment_context.json`
 
 GCS tile outputs:
 
@@ -212,6 +214,7 @@ Frontend public URLs:
 - `https://storage.googleapis.com/musa5090s26-team1-public/configs/current_assessment_bins.json`
 - `https://storage.googleapis.com/musa5090s26-team1-public/configs/tax_year_assessment_bins.json`
 - `https://storage.googleapis.com/musa5090s26-team1-public/configs/map_style_metadata.json`
+- `https://storage.googleapis.com/musa5090s26-team1-public/configs/zip_assessment_context.json`
 - `https://storage.googleapis.com/musa5090s26-team1-public/tiles/properties/{z}/{x}/{y}.pbf`
 
 Cloud Run job executions:

--- a/tasks/data-pipeline/workflow.yaml
+++ b/tasks/data-pipeline/workflow.yaml
@@ -20,6 +20,7 @@ main:
           - export_current_assessment_bins_url: "https://export-current-assessment-bins-bl43esqwsa-uk.a.run.app"
           - export_property_tile_info_url: "https://export-property-tile-info-bl43esqwsa-uk.a.run.app"
           - export_map_style_metadata_url: "https://export-map-style-metadata-bl43esqwsa-uk.a.run.app"
+          - export_zip_assessment_context_url: "https://export-zip-assessment-context-bl43esqwsa-uk.a.run.app"
           - predict_current_assessments_job: "predict-current-assessments"
           - generate_property_map_tiles_job: "generate-property-map-tiles"
           - opa_properties_extract_result: null
@@ -39,6 +40,7 @@ main:
           - export_current_assessment_bins_result: null
           - export_property_tile_info_result: null
           - export_map_style_metadata_result: null
+          - export_zip_assessment_context_result: null
           - generate_property_map_tiles_result: null
 
     - run_ingest_pipelines:
@@ -178,6 +180,7 @@ main:
             - export_current_assessment_bins_result
             - export_property_tile_info_result
             - export_map_style_metadata_result
+            - export_zip_assessment_context_result
             - generate_property_map_tiles_result
           branches:
             - tax_year_chart:
@@ -257,6 +260,18 @@ main:
                         body: {}
                       result: export_map_style_metadata_result
 
+            - zip_assessment_context:
+                steps:
+                  - export_zip_assessment_context:
+                      call: http.post
+                      args:
+                        url: ${export_zip_assessment_context_url}
+                        auth:
+                          type: OIDC
+                        timeout: 1800
+                        body: {}
+                      result: export_zip_assessment_context_result
+
     - done:
         return:
           ingest:
@@ -283,5 +298,6 @@ main:
             current_assessment_bins: ${export_current_assessment_bins_result.body}
             property_tile_info: ${export_property_tile_info_result.body}
             map_style_metadata: ${export_map_style_metadata_result.body}
+            zip_assessment_context: ${export_zip_assessment_context_result.body}
           jobs:
             generate_property_map_tiles: ${generate_property_map_tiles_result}

--- a/tasks/export_property_tile_info/main.py
+++ b/tasks/export_property_tile_info/main.py
@@ -66,9 +66,23 @@ def export_property_tile_info(request):
     SELECT
         parcels.property_id,
         properties.location AS address,
+        properties.zip_code,
         ST_ASGEOJSON(parcels.geog) AS geometry,
         current_predictions.current_assessed_value,
-        latest_assessments.tax_year_assessed_value
+        latest_assessments.tax_year_assessed_value,
+        current_predictions.current_assessed_value
+            - latest_assessments.tax_year_assessed_value AS gap_value,
+        CASE
+            WHEN latest_assessments.tax_year_assessed_value IS NULL
+                OR latest_assessments.tax_year_assessed_value < 10000
+                THEN NULL
+            ELSE
+                SAFE_DIVIDE(
+                    current_predictions.current_assessed_value
+                    - latest_assessments.tax_year_assessed_value,
+                    latest_assessments.tax_year_assessed_value
+                ) * 100
+        END AS gap_pct
     FROM `{project_id}.{core_dataset}.pwd_parcels` AS parcels
     LEFT JOIN `{project_id}.{core_dataset}.opa_properties` AS properties
         ON parcels.property_id = properties.property_id
@@ -102,8 +116,11 @@ def export_property_tile_info(request):
                     "properties": {
                         "property_id": row.property_id,
                         "address": row.address,
+                        "zip_code": row.zip_code,
                         "current_assessed_value": row.current_assessed_value,
                         "tax_year_assessed_value": row.tax_year_assessed_value,
+                        "gap_value": row.gap_value,
+                        "gap_pct": row.gap_pct,
                     },
                 }
             )

--- a/tasks/export_zip_assessment_context/.gcloudignore
+++ b/tasks/export_zip_assessment_context/.gcloudignore
@@ -1,0 +1,9 @@
+.gcloudignore
+.venv/
+venv/
+env/
+__pycache__/
+*.pyc
+.env
+*.log
+.DS_Store

--- a/tasks/export_zip_assessment_context/README.md
+++ b/tasks/export_zip_assessment_context/README.md
@@ -1,0 +1,51 @@
+# Export ZIP Assessment Context
+
+HTTP Cloud Function that exports ZIP-code assessment context for the reviewer
+dashboard and owner widget.
+
+The function writes:
+
+```text
+gs://musa5090s26-team1-public/configs/zip_assessment_context.json
+```
+
+The JSON includes ZIP-level record counts, approximate medians, and compact
+official/model value bins using the same display scale as the citywide chart
+assets.
+
+## Environment Variables
+
+- `PROJECT_ID`, default `musa5090s26-team1`
+- `PUBLIC_BUCKET`, required
+- `BQ_CORE_DATASET`, default `core`
+- `BQ_DERIVED_DATASET`, default `derived`
+
+## Deploy
+
+```bash
+gcloud functions deploy export-zip-assessment-context \
+  --gen2 \
+  --runtime=python312 \
+  --region=us-east4 \
+  --source=tasks/export_zip_assessment_context \
+  --entry-point=export_zip_assessment_context \
+  --trigger-http \
+  --no-allow-unauthenticated \
+  --set-env-vars PROJECT_ID=musa5090s26-team1,PUBLIC_BUCKET=musa5090s26-team1-public,BQ_CORE_DATASET=core,BQ_DERIVED_DATASET=derived
+```
+
+## Local Test
+
+```bash
+cd tasks/export_zip_assessment_context
+python -m pip install -r requirements.txt
+PUBLIC_BUCKET=musa5090s26-team1-public functions-framework \
+  --target export_zip_assessment_context \
+  --port 8080
+```
+
+In another terminal:
+
+```bash
+curl -X POST http://localhost:8080
+```

--- a/tasks/export_zip_assessment_context/main.py
+++ b/tasks/export_zip_assessment_context/main.py
@@ -1,0 +1,240 @@
+import json
+import os
+from datetime import datetime
+from datetime import timezone
+
+import functions_framework
+from dotenv import load_dotenv
+from google.cloud import bigquery
+from google.cloud import storage
+
+load_dotenv()
+
+
+OUTPUT_OBJECT_NAME = "configs/zip_assessment_context.json"
+
+
+@functions_framework.http
+def export_zip_assessment_context(request):
+    del request
+
+    project_id = os.getenv("PROJECT_ID", "musa5090s26-team1")
+    public_bucket = os.getenv("PUBLIC_BUCKET")
+    core_dataset = os.getenv("BQ_CORE_DATASET", "core")
+    derived_dataset = os.getenv("BQ_DERIVED_DATASET", "derived")
+
+    if not public_bucket:
+        return (
+            json.dumps({"ok": False, "error": "Missing PUBLIC_BUCKET"}),
+            500,
+            {"Content-Type": "application/json"},
+        )
+
+    sql = f"""
+    WITH latest_tax_year AS (
+        SELECT
+            MAX(SAFE_CAST(year AS INT64)) AS tax_year
+        FROM `{project_id}.{core_dataset}.opa_assessments`
+        WHERE SAFE_CAST(year AS INT64) IS NOT NULL
+    ),
+
+    latest_assessments AS (
+        SELECT
+            assessments.property_id,
+            MAX(SAFE_CAST(assessments.market_value AS FLOAT64))
+                AS tax_year_assessed_value
+        FROM `{project_id}.{core_dataset}.opa_assessments` AS assessments
+        CROSS JOIN latest_tax_year
+        WHERE SAFE_CAST(assessments.year AS INT64) = latest_tax_year.tax_year
+        GROUP BY assessments.property_id
+    ),
+
+    current_predictions AS (
+        SELECT
+            property_id,
+            SAFE_CAST(predicted_value AS FLOAT64) AS current_assessed_value
+        FROM `{project_id}.{derived_dataset}.current_assessments`
+        QUALIFY ROW_NUMBER() OVER (
+            PARTITION BY property_id
+            ORDER BY predicted_at DESC
+        ) = 1
+    ),
+
+    property_values AS (
+        SELECT
+            properties.zip_code,
+            latest_assessments.tax_year_assessed_value,
+            current_predictions.current_assessed_value,
+            CASE
+                WHEN latest_assessments.tax_year_assessed_value IS NULL
+                    OR latest_assessments.tax_year_assessed_value < 10000
+                    THEN NULL
+                ELSE
+                    SAFE_DIVIDE(
+                        current_predictions.current_assessed_value
+                        - latest_assessments.tax_year_assessed_value,
+                        latest_assessments.tax_year_assessed_value
+                    ) * 100
+            END AS gap_pct
+        FROM `{project_id}.{core_dataset}.opa_properties` AS properties
+        LEFT JOIN latest_assessments
+            ON properties.property_id = latest_assessments.property_id
+        LEFT JOIN current_predictions
+            ON properties.property_id = current_predictions.property_id
+        WHERE
+            REGEXP_CONTAINS(properties.zip_code, r'^\\d{{5}}$')
+            AND properties.category_code_description IN (
+                'SINGLE FAMILY',
+                'MULTI FAMILY',
+                'APARTMENTS > 4 UNITS',
+                'VACANT LAND - RESIDENTIAL',
+                'GARAGE - RESIDENTIAL'
+            )
+    ),
+
+    stats AS (
+        SELECT
+            zip_code,
+            COUNT(*) AS record_count,
+            APPROX_QUANTILES(tax_year_assessed_value, 2)[OFFSET(1)]
+                AS official_median,
+            APPROX_QUANTILES(current_assessed_value, 2)[OFFSET(1)]
+                AS model_median,
+            APPROX_QUANTILES(gap_pct, 2)[OFFSET(1)] AS gap_median_pct
+        FROM property_values
+        GROUP BY zip_code
+    ),
+
+    official_bins AS (
+        SELECT
+            zip_code,
+            LEAST(
+                DIV(CAST(FLOOR(tax_year_assessed_value) AS INT64), 100000)
+                    * 100000,
+                2500000
+            ) AS lower_bound,
+            COUNT(*) AS property_count
+        FROM property_values
+        WHERE tax_year_assessed_value IS NOT NULL
+        GROUP BY zip_code, lower_bound
+    ),
+
+    model_bins AS (
+        SELECT
+            zip_code,
+            LEAST(
+                DIV(CAST(FLOOR(current_assessed_value) AS INT64), 100000)
+                    * 100000,
+                2500000
+            ) AS lower_bound,
+            COUNT(*) AS property_count
+        FROM property_values
+        WHERE current_assessed_value IS NOT NULL
+        GROUP BY zip_code, lower_bound
+    )
+
+    SELECT
+        stats.zip_code,
+        stats.record_count,
+        stats.official_median,
+        stats.model_median,
+        stats.gap_median_pct,
+        ARRAY(
+            SELECT AS STRUCT
+                official_bins.lower_bound,
+                CASE
+                    WHEN official_bins.lower_bound = 2500000 THEN NULL
+                    ELSE official_bins.lower_bound + 100000
+                END AS upper_bound,
+                official_bins.property_count
+            FROM official_bins
+            WHERE official_bins.zip_code = stats.zip_code
+            ORDER BY official_bins.lower_bound
+        ) AS official_bins,
+        ARRAY(
+            SELECT AS STRUCT
+                model_bins.lower_bound,
+                CASE
+                    WHEN model_bins.lower_bound = 2500000 THEN NULL
+                    ELSE model_bins.lower_bound + 100000
+                END AS upper_bound,
+                model_bins.property_count
+            FROM model_bins
+            WHERE model_bins.zip_code = stats.zip_code
+            ORDER BY model_bins.lower_bound
+        ) AS model_bins
+    FROM stats
+    ORDER BY stats.zip_code
+    """
+
+    try:
+        bigquery_client = bigquery.Client()
+        rows = bigquery_client.query(sql).result()
+
+        areas = {}
+        for row in rows:
+            areas[row.zip_code] = {
+                "label": f"ZIP {row.zip_code}",
+                "record_count": row.record_count,
+                "official": {
+                    "approx_median": row.official_median,
+                    "bins": [
+                        {
+                            "lower_bound": item["lower_bound"],
+                            "upper_bound": item["upper_bound"],
+                            "property_count": item["property_count"],
+                        }
+                        for item in row.official_bins
+                    ],
+                },
+                "model": {
+                    "approx_median": row.model_median,
+                    "bins": [
+                        {
+                            "lower_bound": item["lower_bound"],
+                            "upper_bound": item["upper_bound"],
+                            "property_count": item["property_count"],
+                        }
+                        for item in row.model_bins
+                    ],
+                },
+                "gap": {
+                    "approx_median_pct": row.gap_median_pct,
+                },
+            }
+
+        payload = {
+            "geography": "zip_code",
+            "generated_at": datetime.now(timezone.utc)
+            .isoformat()
+            .replace("+00:00", "Z"),
+            "areas": areas,
+        }
+
+        storage_client = storage.Client()
+        bucket = storage_client.bucket(public_bucket)
+        blob = bucket.blob(OUTPUT_OBJECT_NAME)
+        blob.upload_from_string(
+            json.dumps(payload),
+            content_type="application/json",
+            timeout=600,
+        )
+
+        return (
+            json.dumps(
+                {
+                    "ok": True,
+                    "areas": len(areas),
+                    "output_uri": f"gs://{public_bucket}/{OUTPUT_OBJECT_NAME}",
+                }
+            ),
+            200,
+            {"Content-Type": "application/json"},
+        )
+
+    except Exception as e:
+        return (
+            json.dumps({"ok": False, "error": str(e)}),
+            500,
+            {"Content-Type": "application/json"},
+        )

--- a/tasks/export_zip_assessment_context/main.py
+++ b/tasks/export_zip_assessment_context/main.py
@@ -12,6 +12,8 @@ load_dotenv()
 
 
 OUTPUT_OBJECT_NAME = "configs/zip_assessment_context.json"
+MAIN_DISPLAY_MAX = 2500000
+MAIN_DISPLAY_BIN_SIZE = 100000
 
 
 @functions_framework.http
@@ -30,29 +32,24 @@ def export_zip_assessment_context(request):
             {"Content-Type": "application/json"},
         )
 
-    sql = f"""
-    WITH latest_tax_year AS (
+    base_sql = f"""
+    WITH latest_official AS (
         SELECT
-            MAX(SAFE_CAST(year AS INT64)) AS tax_year
+            property_id,
+            SAFE_CAST(year AS INT64) AS tax_year,
+            SAFE_CAST(market_value AS FLOAT64) AS official_value
         FROM `{project_id}.{core_dataset}.opa_assessments`
         WHERE SAFE_CAST(year AS INT64) IS NOT NULL
-    ),
-
-    latest_assessments AS (
-        SELECT
-            assessments.property_id,
-            MAX(SAFE_CAST(assessments.market_value AS FLOAT64))
-                AS tax_year_assessed_value
-        FROM `{project_id}.{core_dataset}.opa_assessments` AS assessments
-        CROSS JOIN latest_tax_year
-        WHERE SAFE_CAST(assessments.year AS INT64) = latest_tax_year.tax_year
-        GROUP BY assessments.property_id
+        QUALIFY ROW_NUMBER() OVER (
+            PARTITION BY property_id
+            ORDER BY SAFE_CAST(year AS INT64) DESC
+        ) = 1
     ),
 
     current_predictions AS (
         SELECT
             property_id,
-            SAFE_CAST(predicted_value AS FLOAT64) AS current_assessed_value
+            SAFE_CAST(predicted_value AS FLOAT64) AS model_value
         FROM `{project_id}.{derived_dataset}.current_assessments`
         QUALIFY ROW_NUMBER() OVER (
             PARTITION BY property_id
@@ -60,25 +57,25 @@ def export_zip_assessment_context(request):
         ) = 1
     ),
 
-    property_values AS (
+    base AS (
         SELECT
             properties.zip_code,
-            latest_assessments.tax_year_assessed_value,
-            current_predictions.current_assessed_value,
+            properties.property_id,
+            latest_official.official_value,
+            current_predictions.model_value,
             CASE
-                WHEN latest_assessments.tax_year_assessed_value IS NULL
-                    OR latest_assessments.tax_year_assessed_value < 10000
+                WHEN latest_official.official_value IS NULL
+                    OR latest_official.official_value < 10000
                     THEN NULL
                 ELSE
                     SAFE_DIVIDE(
-                        current_predictions.current_assessed_value
-                        - latest_assessments.tax_year_assessed_value,
-                        latest_assessments.tax_year_assessed_value
+                        current_predictions.model_value - latest_official.official_value,
+                        latest_official.official_value
                     ) * 100
             END AS gap_pct
         FROM `{project_id}.{core_dataset}.opa_properties` AS properties
-        LEFT JOIN latest_assessments
-            ON properties.property_id = latest_assessments.property_id
+        LEFT JOIN latest_official
+            ON properties.property_id = latest_official.property_id
         LEFT JOIN current_predictions
             ON properties.property_id = current_predictions.property_id
         WHERE
@@ -90,118 +87,125 @@ def export_zip_assessment_context(request):
                 'VACANT LAND - RESIDENTIAL',
                 'GARAGE - RESIDENTIAL'
             )
-    ),
-
-    stats AS (
-        SELECT
-            zip_code,
-            COUNT(*) AS record_count,
-            APPROX_QUANTILES(tax_year_assessed_value, 2)[OFFSET(1)]
-                AS official_median,
-            APPROX_QUANTILES(current_assessed_value, 2)[OFFSET(1)]
-                AS model_median,
-            APPROX_QUANTILES(gap_pct, 2)[OFFSET(1)] AS gap_median_pct
-        FROM property_values
-        GROUP BY zip_code
-    ),
-
-    official_bins AS (
-        SELECT
-            zip_code,
-            LEAST(
-                DIV(CAST(FLOOR(tax_year_assessed_value) AS INT64), 100000)
-                    * 100000,
-                2500000
-            ) AS lower_bound,
-            COUNT(*) AS property_count
-        FROM property_values
-        WHERE tax_year_assessed_value IS NOT NULL
-        GROUP BY zip_code, lower_bound
-    ),
-
-    model_bins AS (
-        SELECT
-            zip_code,
-            LEAST(
-                DIV(CAST(FLOOR(current_assessed_value) AS INT64), 100000)
-                    * 100000,
-                2500000
-            ) AS lower_bound,
-            COUNT(*) AS property_count
-        FROM property_values
-        WHERE current_assessed_value IS NOT NULL
-        GROUP BY zip_code, lower_bound
     )
+    """
+
+    summary_sql = f"""
+    {base_sql}
 
     SELECT
-        stats.zip_code,
-        stats.record_count,
-        stats.official_median,
-        stats.model_median,
-        stats.gap_median_pct,
-        ARRAY(
-            SELECT AS STRUCT
-                official_bins.lower_bound,
-                CASE
-                    WHEN official_bins.lower_bound = 2500000 THEN NULL
-                    ELSE official_bins.lower_bound + 100000
-                END AS upper_bound,
-                official_bins.property_count
-            FROM official_bins
-            WHERE official_bins.zip_code = stats.zip_code
-            ORDER BY official_bins.lower_bound
-        ) AS official_bins,
-        ARRAY(
-            SELECT AS STRUCT
-                model_bins.lower_bound,
-                CASE
-                    WHEN model_bins.lower_bound = 2500000 THEN NULL
-                    ELSE model_bins.lower_bound + 100000
-                END AS upper_bound,
-                model_bins.property_count
-            FROM model_bins
-            WHERE model_bins.zip_code = stats.zip_code
-            ORDER BY model_bins.lower_bound
-        ) AS model_bins
-    FROM stats
-    ORDER BY stats.zip_code
+        zip_code,
+        COUNT(*) AS record_count,
+        APPROX_QUANTILES(official_value, 100)[OFFSET(50)]
+            AS official_approx_median,
+        APPROX_QUANTILES(model_value, 100)[OFFSET(50)]
+            AS model_approx_median,
+        APPROX_QUANTILES(gap_pct, 100)[OFFSET(50)]
+            AS gap_approx_median_pct
+    FROM base
+    GROUP BY zip_code
+    ORDER BY zip_code
+    """
+
+    official_bins_sql = f"""
+    {base_sql}
+
+    SELECT
+        zip_code,
+        lower_bound,
+        CASE
+            WHEN lower_bound = {MAIN_DISPLAY_MAX} THEN NULL
+            ELSE lower_bound + {MAIN_DISPLAY_BIN_SIZE}
+        END AS upper_bound,
+        COUNT(*) AS property_count
+    FROM (
+        SELECT
+            zip_code,
+            CAST(
+                FLOOR(
+                    LEAST(official_value, {MAIN_DISPLAY_MAX})
+                    / {MAIN_DISPLAY_BIN_SIZE}
+                ) * {MAIN_DISPLAY_BIN_SIZE}
+                AS INT64
+            ) AS lower_bound
+        FROM base
+        WHERE official_value IS NOT NULL
+    )
+    GROUP BY zip_code, lower_bound, upper_bound
+    ORDER BY zip_code, lower_bound
+    """
+
+    model_bins_sql = f"""
+    {base_sql}
+
+    SELECT
+        zip_code,
+        lower_bound,
+        CASE
+            WHEN lower_bound = {MAIN_DISPLAY_MAX} THEN NULL
+            ELSE lower_bound + {MAIN_DISPLAY_BIN_SIZE}
+        END AS upper_bound,
+        COUNT(*) AS property_count
+    FROM (
+        SELECT
+            zip_code,
+            CAST(
+                FLOOR(
+                    LEAST(model_value, {MAIN_DISPLAY_MAX})
+                    / {MAIN_DISPLAY_BIN_SIZE}
+                ) * {MAIN_DISPLAY_BIN_SIZE}
+                AS INT64
+            ) AS lower_bound,
+        FROM base
+        WHERE model_value IS NOT NULL
+    )
+    GROUP BY zip_code, lower_bound, upper_bound
+    ORDER BY zip_code, lower_bound
     """
 
     try:
         bigquery_client = bigquery.Client()
-        rows = bigquery_client.query(sql).result()
+        summary_rows = bigquery_client.query(summary_sql).result()
 
         areas = {}
-        for row in rows:
+        for row in summary_rows:
             areas[row.zip_code] = {
                 "label": f"ZIP {row.zip_code}",
                 "record_count": row.record_count,
                 "official": {
-                    "approx_median": row.official_median,
-                    "bins": [
-                        {
-                            "lower_bound": item["lower_bound"],
-                            "upper_bound": item["upper_bound"],
-                            "property_count": item["property_count"],
-                        }
-                        for item in row.official_bins
-                    ],
+                    "approx_median": row.official_approx_median,
+                    "bins": [],
                 },
                 "model": {
-                    "approx_median": row.model_median,
-                    "bins": [
-                        {
-                            "lower_bound": item["lower_bound"],
-                            "upper_bound": item["upper_bound"],
-                            "property_count": item["property_count"],
-                        }
-                        for item in row.model_bins
-                    ],
+                    "approx_median": row.model_approx_median,
+                    "bins": [],
                 },
                 "gap": {
-                    "approx_median_pct": row.gap_median_pct,
+                    "approx_median_pct": row.gap_approx_median_pct,
                 },
             }
+
+        official_bin_rows = bigquery_client.query(official_bins_sql).result()
+        for row in official_bin_rows:
+            if row.zip_code in areas:
+                areas[row.zip_code]["official"]["bins"].append(
+                    {
+                        "lower_bound": row.lower_bound,
+                        "upper_bound": row.upper_bound,
+                        "property_count": row.property_count,
+                    }
+                )
+
+        model_bin_rows = bigquery_client.query(model_bins_sql).result()
+        for row in model_bin_rows:
+            if row.zip_code in areas:
+                areas[row.zip_code]["model"]["bins"].append(
+                    {
+                        "lower_bound": row.lower_bound,
+                        "upper_bound": row.upper_bound,
+                        "property_count": row.property_count,
+                    }
+                )
 
         payload = {
             "geography": "zip_code",

--- a/tasks/export_zip_assessment_context/requirements.txt
+++ b/tasks/export_zip_assessment_context/requirements.txt
@@ -1,0 +1,4 @@
+functions-framework==3.*
+google-cloud-bigquery
+google-cloud-storage
+python-dotenv

--- a/tasks/property-assessment-lookup/.gcloudignore
+++ b/tasks/property-assessment-lookup/.gcloudignore
@@ -1,0 +1,9 @@
+﻿.gcloudignore
+.venv/
+venv/
+env/
+__pycache__/
+*.pyc
+.env
+*.log
+.DS_Store

--- a/tasks/property-assessment-lookup/README.md
+++ b/tasks/property-assessment-lookup/README.md
@@ -24,6 +24,7 @@ It also handles `OPTIONS` requests for browser CORS preflight.
   "ok": true,
   "property": {
     "property_id": "502244720",
+    "zip_code": "19104",
     "address": "1234 MAIN ST",
     "property_type": "SINGLE FAMILY"
   },
@@ -43,6 +44,18 @@ It also handles `OPTIONS` requests for browser CORS preflight.
     "predicted_at": "2026-04-29T03:16:30Z",
     "gap_value": 13500,
     "gap_pct": 0.072
+  },
+  "context": {
+    "citywide": {
+      "official_percentile": 63.2,
+      "model_percentile": 68.5
+    },
+    "zip": {
+      "zip_code": "19104",
+      "label": "ZIP 19104",
+      "official_percentile": 55.4,
+      "model_percentile": 61.1
+    }
   }
 }
 ```

--- a/tasks/property-assessment-lookup/README.md
+++ b/tasks/property-assessment-lookup/README.md
@@ -1,0 +1,81 @@
+﻿# Property Assessment Lookup
+
+HTTP Cloud Function for the owner-facing assessment widget. It returns one property's official assessment history and current model estimate from BigQuery.
+
+## Endpoint
+
+`property_assessment_lookup(request)` supports `GET` requests with either query parameter:
+
+- `property_id`
+- `opa_id`
+
+It also handles `OPTIONS` requests for browser CORS preflight.
+
+## Environment Variables
+
+- `PROJECT_ID`, default `musa5090s26-team1`
+- `BQ_CORE_DATASET`, default `core`
+- `BQ_DERIVED_DATASET`, default `derived`
+
+## Response Shape
+
+```json
+{
+  "ok": true,
+  "property": {
+    "property_id": "502244720",
+    "address": "1234 MAIN ST",
+    "property_type": "SINGLE FAMILY"
+  },
+  "official": {
+    "latest_tax_year": 2026,
+    "latest_assessed_value": 187500,
+    "prior_tax_year": 2025,
+    "prior_assessed_value": 181700,
+    "change_pct": 0.032
+  },
+  "history": [
+    {"tax_year": 2025, "assessed_value": 181700},
+    {"tax_year": 2026, "assessed_value": 187500}
+  ],
+  "estimate": {
+    "estimated_current_market_value": 201000,
+    "predicted_at": "2026-04-29T03:16:30Z",
+    "gap_value": 13500,
+    "gap_pct": 0.072
+  }
+}
+```
+
+## Deploy
+
+```bash
+gcloud functions deploy property-assessment-lookup \
+  --gen2 \
+  --runtime=python312 \
+  --region=us-east4 \
+  --source=tasks/property-assessment-lookup \
+  --entry-point=property_assessment_lookup \
+  --trigger-http \
+  --allow-unauthenticated \
+  --set-env-vars PROJECT_ID=musa5090s26-team1,BQ_CORE_DATASET=core,BQ_DERIVED_DATASET=derived
+```
+
+## Local Test
+
+```bash
+cd tasks/property-assessment-lookup
+python -m pip install -r requirements.txt
+PROJECT_ID=musa5090s26-team1 BQ_CORE_DATASET=core BQ_DERIVED_DATASET=derived \
+  functions-framework --target property_assessment_lookup --port 8080
+```
+
+In another terminal:
+
+```bash
+curl "http://localhost:8080/?property_id=502244720"
+```
+
+## Notes
+
+The query uses BigQuery parameters for the property identifier. The browser never connects directly to BigQuery.

--- a/tasks/property-assessment-lookup/main.py
+++ b/tasks/property-assessment-lookup/main.py
@@ -1,0 +1,204 @@
+﻿import json
+import os
+
+import functions_framework
+from dotenv import load_dotenv
+from google.cloud import bigquery
+
+load_dotenv()
+
+
+CORS_HEADERS = {
+    "Access-Control-Allow-Origin": "*",
+    "Access-Control-Allow-Methods": "GET, OPTIONS",
+    "Access-Control-Allow-Headers": "Content-Type",
+    "Access-Control-Max-Age": "3600",
+}
+
+
+@functions_framework.http
+def property_assessment_lookup(request):
+    if request.method == "OPTIONS":
+        return ("", 204, CORS_HEADERS)
+
+    if request.method != "GET":
+        return (
+            json.dumps({"ok": False, "error": "Only GET is supported"}),
+            405,
+            {**CORS_HEADERS, "Content-Type": "application/json"},
+        )
+
+    project_id = os.getenv("PROJECT_ID", "musa5090s26-team1")
+    core_dataset = os.getenv("BQ_CORE_DATASET", "core")
+    derived_dataset = os.getenv("BQ_DERIVED_DATASET", "derived")
+    property_id = (
+        request.args.get("property_id") or request.args.get("opa_id") or ""
+    ).strip()
+
+    if not property_id:
+        return (
+            json.dumps({"ok": False, "error": "Missing property_id or opa_id"}),
+            400,
+            {**CORS_HEADERS, "Content-Type": "application/json"},
+        )
+
+    sql = f"""
+    WITH property AS (
+        SELECT
+            property_id,
+            parcel_number,
+            location AS address,
+            category_code_description AS property_type
+        FROM `{project_id}.{core_dataset}.opa_properties`
+        WHERE property_id = @property_id OR parcel_number = @property_id
+        QUALIFY ROW_NUMBER() OVER (
+            PARTITION BY property_id
+            ORDER BY property_id
+        ) = 1
+    ),
+
+    history AS (
+        SELECT
+            assessments.property_id,
+            SAFE_CAST(assessments.year AS INT64) AS tax_year,
+            SAFE_CAST(assessments.market_value AS FLOAT64) AS assessed_value
+        FROM `{project_id}.{core_dataset}.opa_assessments` AS assessments
+        INNER JOIN property
+            ON assessments.property_id = property.property_id
+        WHERE
+            SAFE_CAST(assessments.year AS INT64) IS NOT NULL
+            AND SAFE_CAST(assessments.market_value AS FLOAT64) IS NOT NULL
+    ),
+
+    ranked_history AS (
+        SELECT
+            property_id,
+            tax_year,
+            assessed_value,
+            ROW_NUMBER() OVER (
+                PARTITION BY property_id
+                ORDER BY tax_year DESC
+            ) AS recency_rank
+        FROM history
+    ),
+
+    latest_estimate AS (
+        SELECT
+            estimates.property_id,
+            SAFE_CAST(estimates.predicted_value AS FLOAT64)
+                AS estimated_current_market_value,
+            estimates.predicted_at
+        FROM `{project_id}.{derived_dataset}.current_assessments` AS estimates
+        INNER JOIN property
+            ON estimates.property_id = property.property_id
+        QUALIFY ROW_NUMBER() OVER (
+            PARTITION BY estimates.property_id
+            ORDER BY estimates.predicted_at DESC
+        ) = 1
+    )
+
+    SELECT
+        property.property_id,
+        property.address,
+        property.property_type,
+        latest.tax_year AS latest_tax_year,
+        latest.assessed_value AS latest_assessed_value,
+        prior.tax_year AS prior_tax_year,
+        prior.assessed_value AS prior_assessed_value,
+        ARRAY(
+            SELECT AS STRUCT
+                tax_year,
+                assessed_value
+            FROM history
+            ORDER BY tax_year
+        ) AS history,
+        latest_estimate.estimated_current_market_value,
+        latest_estimate.predicted_at
+    FROM property
+    LEFT JOIN ranked_history AS latest
+        ON property.property_id = latest.property_id
+        AND latest.recency_rank = 1
+    LEFT JOIN ranked_history AS prior
+        ON property.property_id = prior.property_id
+        AND prior.recency_rank = 2
+    LEFT JOIN latest_estimate
+        ON property.property_id = latest_estimate.property_id
+    """
+
+    try:
+        client = bigquery.Client()
+        job_config = bigquery.QueryJobConfig(
+            query_parameters=[
+                bigquery.ScalarQueryParameter("property_id", "STRING", property_id)
+            ]
+        )
+        rows = list(client.query(sql, job_config=job_config).result())
+
+        if not rows:
+            return (
+                json.dumps({"ok": False, "error": "Property not found"}),
+                404,
+                {**CORS_HEADERS, "Content-Type": "application/json"},
+            )
+
+        row = rows[0]
+        latest_value = row.latest_assessed_value
+        prior_value = row.prior_assessed_value
+        estimate_value = row.estimated_current_market_value
+
+        official_change_pct = None
+        if latest_value is not None and prior_value not in (None, 0):
+            official_change_pct = (latest_value - prior_value) / prior_value
+
+        gap_value = None
+        gap_pct = None
+        if estimate_value is not None and latest_value is not None:
+            gap_value = estimate_value - latest_value
+            if latest_value != 0:
+                gap_pct = gap_value / latest_value
+
+        predicted_at = row.predicted_at
+        if predicted_at is not None:
+            predicted_at = predicted_at.isoformat().replace("+00:00", "Z")
+
+        response = {
+            "ok": True,
+            "property": {
+                "property_id": row.property_id,
+                "address": row.address,
+                "property_type": row.property_type,
+            },
+            "official": {
+                "latest_tax_year": row.latest_tax_year,
+                "latest_assessed_value": latest_value,
+                "prior_tax_year": row.prior_tax_year,
+                "prior_assessed_value": prior_value,
+                "change_pct": official_change_pct,
+            },
+            "history": [
+                {
+                    "tax_year": item["tax_year"],
+                    "assessed_value": item["assessed_value"],
+                }
+                for item in row.history
+            ],
+            "estimate": {
+                "estimated_current_market_value": estimate_value,
+                "predicted_at": predicted_at,
+                "gap_value": gap_value,
+                "gap_pct": gap_pct,
+            },
+        }
+
+        return (
+            json.dumps(response),
+            200,
+            {**CORS_HEADERS, "Content-Type": "application/json"},
+        )
+
+    except Exception as e:
+        return (
+            json.dumps({"ok": False, "error": str(e)}),
+            500,
+            {**CORS_HEADERS, "Content-Type": "application/json"},
+        )

--- a/tasks/property-assessment-lookup/main.py
+++ b/tasks/property-assessment-lookup/main.py
@@ -47,6 +47,7 @@ def property_assessment_lookup(request):
         SELECT
             property_id,
             parcel_number,
+            zip_code,
             location AS address,
             category_code_description AS property_type
         FROM `{project_id}.{core_dataset}.opa_properties`
@@ -70,6 +71,82 @@ def property_assessment_lookup(request):
             AND SAFE_CAST(assessments.market_value AS FLOAT64) IS NOT NULL
     ),
 
+    latest_assessments AS (
+        SELECT
+            assessments.property_id,
+            MAX(SAFE_CAST(assessments.market_value AS FLOAT64))
+                AS tax_year_assessed_value
+        FROM `{project_id}.{core_dataset}.opa_assessments` AS assessments
+        WHERE SAFE_CAST(assessments.year AS INT64) = (
+            SELECT MAX(SAFE_CAST(year AS INT64))
+            FROM `{project_id}.{core_dataset}.opa_assessments`
+            WHERE SAFE_CAST(year AS INT64) IS NOT NULL
+        )
+        GROUP BY assessments.property_id
+    ),
+
+    current_predictions AS (
+        SELECT
+            property_id,
+            SAFE_CAST(predicted_value AS FLOAT64) AS current_assessed_value,
+            predicted_at
+        FROM `{project_id}.{derived_dataset}.current_assessments`
+        QUALIFY ROW_NUMBER() OVER (
+            PARTITION BY property_id
+            ORDER BY predicted_at DESC
+        ) = 1
+    ),
+
+    property_values AS (
+        SELECT
+            properties.property_id,
+            properties.zip_code,
+            latest_assessments.tax_year_assessed_value,
+            current_predictions.current_assessed_value
+        FROM `{project_id}.{core_dataset}.opa_properties` AS properties
+        LEFT JOIN latest_assessments
+            ON properties.property_id = latest_assessments.property_id
+        LEFT JOIN current_predictions
+            ON properties.property_id = current_predictions.property_id
+        WHERE properties.category_code_description IN (
+            'SINGLE FAMILY',
+            'MULTI FAMILY',
+            'APARTMENTS > 4 UNITS',
+            'VACANT LAND - RESIDENTIAL',
+            'GARAGE - RESIDENTIAL'
+        )
+    ),
+
+    official_percentiles AS (
+        SELECT
+            property_id,
+            zip_code,
+            CUME_DIST() OVER (
+                ORDER BY tax_year_assessed_value
+            ) * 100 AS official_citywide_percentile,
+            CUME_DIST() OVER (
+                PARTITION BY zip_code
+                ORDER BY tax_year_assessed_value
+            ) * 100 AS official_zip_percentile
+        FROM property_values
+        WHERE tax_year_assessed_value IS NOT NULL
+    ),
+
+    model_percentiles AS (
+        SELECT
+            property_id,
+            zip_code,
+            CUME_DIST() OVER (
+                ORDER BY current_assessed_value
+            ) * 100 AS model_citywide_percentile,
+            CUME_DIST() OVER (
+                PARTITION BY zip_code
+                ORDER BY current_assessed_value
+            ) * 100 AS model_zip_percentile
+        FROM property_values
+        WHERE current_assessed_value IS NOT NULL
+    ),
+
     ranked_history AS (
         SELECT
             property_id,
@@ -84,21 +161,18 @@ def property_assessment_lookup(request):
 
     latest_estimate AS (
         SELECT
-            estimates.property_id,
-            SAFE_CAST(estimates.predicted_value AS FLOAT64)
+            current_predictions.property_id,
+            current_predictions.current_assessed_value
                 AS estimated_current_market_value,
-            estimates.predicted_at
-        FROM `{project_id}.{derived_dataset}.current_assessments` AS estimates
+            current_predictions.predicted_at
+        FROM current_predictions
         INNER JOIN property
-            ON estimates.property_id = property.property_id
-        QUALIFY ROW_NUMBER() OVER (
-            PARTITION BY estimates.property_id
-            ORDER BY estimates.predicted_at DESC
-        ) = 1
+            ON current_predictions.property_id = property.property_id
     )
 
     SELECT
         property.property_id,
+        property.zip_code,
         property.address,
         property.property_type,
         latest.tax_year AS latest_tax_year,
@@ -113,7 +187,11 @@ def property_assessment_lookup(request):
             ORDER BY tax_year
         ) AS history,
         latest_estimate.estimated_current_market_value,
-        latest_estimate.predicted_at
+        latest_estimate.predicted_at,
+        official_percentiles.official_citywide_percentile,
+        official_percentiles.official_zip_percentile,
+        model_percentiles.model_citywide_percentile,
+        model_percentiles.model_zip_percentile
     FROM property
     LEFT JOIN ranked_history AS latest
         ON property.property_id = latest.property_id
@@ -123,6 +201,10 @@ def property_assessment_lookup(request):
         AND prior.recency_rank = 2
     LEFT JOIN latest_estimate
         ON property.property_id = latest_estimate.property_id
+    LEFT JOIN official_percentiles
+        ON property.property_id = official_percentiles.property_id
+    LEFT JOIN model_percentiles
+        ON property.property_id = model_percentiles.property_id
     """
 
     try:
@@ -165,6 +247,7 @@ def property_assessment_lookup(request):
             "ok": True,
             "property": {
                 "property_id": row.property_id,
+                "zip_code": row.zip_code,
                 "address": row.address,
                 "property_type": row.property_type,
             },
@@ -188,7 +271,22 @@ def property_assessment_lookup(request):
                 "gap_value": gap_value,
                 "gap_pct": gap_pct,
             },
+            "context": {
+                "citywide": {
+                    "official_percentile": row.official_citywide_percentile,
+                    "model_percentile": row.model_citywide_percentile,
+                },
+                "zip": None,
+            },
         }
+
+        if row.zip_code:
+            response["context"]["zip"] = {
+                "zip_code": row.zip_code,
+                "label": f"ZIP {row.zip_code}",
+                "official_percentile": row.official_zip_percentile,
+                "model_percentile": row.model_zip_percentile,
+            }
 
         return (
             json.dumps(response),

--- a/tasks/property-assessment-lookup/requirements.txt
+++ b/tasks/property-assessment-lookup/requirements.txt
@@ -1,0 +1,3 @@
+﻿functions-framework==3.*
+google-cloud-bigquery
+python-dotenv

--- a/ui/reviewer/index.html
+++ b/ui/reviewer/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+﻿<!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
@@ -9,121 +9,91 @@
   <link rel="stylesheet" href="./style.css" />
 </head>
 <body>
-  <header class="topbar">
-    <div>
-      <h1>CAMA Reviewer Dashboard</h1>
-      <p>Philadelphia property assessment review interface</p>
-    </div>
-  </header>
-
-  <main class="page">
-    <section class="filters">
-      <select>
-        <option>All Neighborhoods</option>
-        <option>Center City</option>
-        <option>University City</option>
-        <option>West Philadelphia</option>
-      </select>
-
-      <select>
-        <option>Predicted Value</option>
-        <option>Percent Change</option>
-        <option>Current Value</option>
-        <option>Previous Value</option>
-      </select>
-
-      <select>
-        <option>2025</option>
-        <option>2024</option>
-        <option>2023</option>
-      </select>
-    </section>
-
-    <section class="dashboard-top">
-      <div class="card map-card">
-        <div class="card-header">
-          <h2>Map View</h2>
-          <p>Citywide spatial context for property assessment review</p>
+  <main class="reviewer-page">
+    <section class="map-panel" aria-label="Property review map">
+      <div class="map-toolbar">
+        <div>
+          <p class="eyebrow">Philadelphia CAMA</p>
+          <h1>Reviewer Dashboard</h1>
         </div>
-        <div id="map"></div>
+        <div class="mode-toggle" aria-label="Map value mode">
+          <button type="button" class="mode-button active" data-mode="official">Official Value</button>
+          <button type="button" class="mode-button" data-mode="estimate">Model Estimate</button>
+          <button type="button" class="mode-button" data-mode="gap">Gap (%)</button>
+        </div>
       </div>
-
-      <div class="side-panel">
-  <div class="card summary-card">
-    <h2>Summary</h2>
-    <div class="summary-list">
-      <p><span>Total Properties</span><strong>582,314</strong></p>
-      <p><span>Median Predicted Value</span><strong>$87,500</strong></p>
-      <p><span>Most Common Range</span><strong>$20k–$30k</strong></p>
-      <p><span>Peak Bin Count</span><strong>38,318</strong></p>
-    </div>
-  </div>
-
-  <div class="card legend-card">
-    <h2>Assessed Value Legend</h2>
-
-    <div class="legend-row">
-      <span class="legend-color legend-1"></span>
-      <span>$0–$100,000</span>
-    </div>
-
-    <div class="legend-row">
-      <span class="legend-color legend-2"></span>
-      <span>$100,000–$250,000</span>
-    </div>
-
-    <div class="legend-row">
-      <span class="legend-color legend-3"></span>
-      <span>$250,000–$500,000</span>
-    </div>
-
-    <div class="legend-row">
-      <span class="legend-color legend-4"></span>
-      <span>$500,000–$750,000</span>
-    </div>
-
-    <div class="legend-row">
-      <span class="legend-color legend-5"></span>
-      <span>$750,000–$1,000,000</span>
-    </div>
-
-    <div class="legend-row">
-      <span class="legend-color legend-6"></span>
-      <span>$1,000,000+</span>
-    </div>
-  </div>
-</div>
+      <div id="map"></div>
+      <p id="mapStatus" class="status-text" role="status" aria-live="polite">
+        Loading public map assets...
+      </p>
     </section>
 
-    <section class="dashboard-bottom">
-      <div class="card distribution-card">
-        <h2>Distribution of Predicted Property Values</h2>
-        <p class="card-subtitle">Count of properties by predicted value range</p>
-
-        <div class="chart-shell">
-          <div class="chart-yaxis" id="distributionYAxis"></div>
-         <div id="distributionChart" class="chart-area"></div>
-        </div>
-
-        <p class="chart-note">
-          All value bins are included; x-axis labels are sampled for readability.
+    <aside class="sidebar" aria-label="Review details">
+      <section id="citywidePanel" class="sidebar-section">
+        <p class="eyebrow">Citywide context</p>
+        <h2>Assessment review</h2>
+        <p id="modeLabel" class="sidebar-copy">
+          Showing official assessed value across residential parcels.
         </p>
-      </div>
 
-      <div class="card trend-card">
-        <div class="card-header">
-          <h2>Trend / Notes</h2>
-          <p>Reserved for additional comparisons, notes, or future metrics</p>
+        <dl id="citywideSummary" class="summary-grid">
+          <div>
+            <dt>Records in map asset</dt>
+            <dd id="recordCountText">-</dd>
+          </div>
+          <div>
+            <dt>Default field</dt>
+            <dd id="defaultFieldText">-</dd>
+          </div>
+        </dl>
+
+        <div class="chart-card">
+          <h3>Official assessment distribution</h3>
+          <p id="officialChartHelper" class="helper-text">Loading public config...</p>
+          <div id="officialDistributionChart" class="mini-chart"></div>
         </div>
-        <div class="empty-chart">
-          <p>No additional trend data available yet</p>
+
+        <div class="chart-card">
+          <h3>Model estimate distribution</h3>
+          <p id="modelChartHelper" class="helper-text">Loading public config...</p>
+          <div id="modelDistributionChart" class="mini-chart"></div>
         </div>
-      </div>
-    </section>
+
+        <p class="instruction-text">Click a parcel on the map to inspect property-level values.</p>
+      </section>
+
+      <section id="selectedPanel" class="sidebar-section" hidden>
+        <button id="clearSelectionBtn" type="button" class="text-button">Clear selection</button>
+        <p class="eyebrow">Selected property</p>
+        <h2 id="selectedAddress">Address not available</h2>
+        <dl class="detail-list">
+          <div>
+            <dt>OPA ID</dt>
+            <dd id="selectedPropertyId">-</dd>
+          </div>
+          <div>
+            <dt>Official Assessed Value</dt>
+            <dd id="selectedOfficialValue">-</dd>
+          </div>
+          <div>
+            <dt>Model Estimate</dt>
+            <dd id="selectedEstimateValue">-</dd>
+          </div>
+          <div>
+            <dt>Gap</dt>
+            <dd id="selectedGapValue">-</dd>
+          </div>
+        </dl>
+        <p class="sidebar-copy">
+          The map shows one value dimension at a time. Official values and model estimates are separated so reviewers can compare them deliberately.
+        </p>
+      </section>
+    </aside>
   </main>
 
   <script src="https://unpkg.com/leaflet/dist/leaflet.js"></script>
   <script src="https://unpkg.com/leaflet.vectorgrid@1.3.0/dist/Leaflet.VectorGrid.bundled.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/apexcharts"></script>
   <script src="./main.js"></script>
 </body>
 </html>

--- a/ui/reviewer/index.html
+++ b/ui/reviewer/index.html
@@ -31,9 +31,6 @@
         </div>
       </div>
       <div id="map"></div>
-      <p id="zipZoomMessage" class="zip-zoom-message" hidden>
-        Zoom in to inspect ZIP-level parcels.
-      </p>
       <p id="mapStatus" class="status-text" role="status" aria-live="polite">
         Loading public map assets...
       </p>

--- a/ui/reviewer/index.html
+++ b/ui/reviewer/index.html
@@ -31,6 +31,9 @@
         </div>
       </div>
       <div id="map"></div>
+      <p id="zipZoomMessage" class="zip-zoom-message" hidden>
+        Zoom in to inspect ZIP-level parcels.
+      </p>
       <p id="mapStatus" class="status-text" role="status" aria-live="polite">
         Loading public map assets...
       </p>
@@ -67,13 +70,13 @@
           </div>
         </dl>
 
-        <div class="chart-card">
+        <div class="chart-card chart-card-primary">
           <h3>Official assessment distribution</h3>
           <p id="officialChartHelper" class="helper-text">Loading public config...</p>
           <div id="officialDistributionChart" class="mini-chart"></div>
         </div>
 
-        <div class="chart-card">
+        <div class="chart-card chart-card-secondary">
           <h3>Model estimate distribution</h3>
           <p id="modelChartHelper" class="helper-text">Loading public config...</p>
           <div id="modelDistributionChart" class="mini-chart"></div>
@@ -84,42 +87,56 @@
 
       <section id="selectedPanel" class="sidebar-section" hidden>
         <button id="clearSelectionBtn" type="button" class="text-button">Clear selection</button>
-        <p class="eyebrow">Selected property</p>
-        <h2 id="selectedAddress">Address not available</h2>
-        <dl class="detail-list">
-          <div>
-            <dt>OPA ID</dt>
-            <dd id="selectedPropertyId">-</dd>
-          </div>
-          <div>
-            <dt>Official Assessed Value</dt>
-            <dd id="selectedOfficialValue">-</dd>
-          </div>
-          <div>
-            <dt>Model Estimate</dt>
-            <dd id="selectedEstimateValue">-</dd>
-          </div>
-          <div>
-            <dt>Gap</dt>
-            <dd id="selectedGapValue">-</dd>
-          </div>
-          <div>
-            <dt>Official percentile citywide</dt>
-            <dd id="selectedOfficialCitywidePercentile">-</dd>
-          </div>
-          <div>
-            <dt>Official percentile in ZIP</dt>
-            <dd id="selectedOfficialZipPercentile">-</dd>
-          </div>
-          <div>
-            <dt>Model percentile citywide</dt>
-            <dd id="selectedModelCitywidePercentile">-</dd>
-          </div>
-          <div>
-            <dt>Model percentile in ZIP</dt>
-            <dd id="selectedModelZipPercentile">-</dd>
-          </div>
-        </dl>
+        <div class="selected-group property-identity">
+          <p class="eyebrow">Selected property</p>
+          <h2 id="selectedAddress">Address not available</h2>
+          <dl class="detail-list">
+            <div>
+              <dt>OPA ID</dt>
+              <dd id="selectedPropertyId">-</dd>
+            </div>
+          </dl>
+        </div>
+
+        <div class="selected-group comparison-block">
+          <h3>Comparison</h3>
+          <dl class="detail-list">
+            <div>
+              <dt>Official Assessed Value</dt>
+              <dd id="selectedOfficialValue">-</dd>
+            </div>
+            <div>
+              <dt>Model Estimate</dt>
+              <dd id="selectedEstimateValue">-</dd>
+            </div>
+            <div>
+              <dt>Gap</dt>
+              <dd id="selectedGapValue">-</dd>
+            </div>
+          </dl>
+        </div>
+
+        <div class="selected-group context-block">
+          <h3>Context</h3>
+          <dl class="detail-list">
+            <div>
+              <dt>Official percentile citywide</dt>
+              <dd id="selectedOfficialCitywidePercentile">-</dd>
+            </div>
+            <div>
+              <dt>Official percentile in ZIP</dt>
+              <dd id="selectedOfficialZipPercentile">-</dd>
+            </div>
+            <div>
+              <dt>Model percentile citywide</dt>
+              <dd id="selectedModelCitywidePercentile">-</dd>
+            </div>
+            <div>
+              <dt>Model percentile in ZIP</dt>
+              <dd id="selectedModelZipPercentile">-</dd>
+            </div>
+          </dl>
+        </div>
         <p class="sidebar-copy">
           The map shows one value dimension at a time. Official values and model estimates are separated so reviewers can compare them deliberately.
         </p>

--- a/ui/reviewer/index.html
+++ b/ui/reviewer/index.html
@@ -16,10 +16,18 @@
           <p class="eyebrow">Philadelphia CAMA</p>
           <h1>Reviewer Dashboard</h1>
         </div>
-        <div class="mode-toggle" aria-label="Map value mode">
-          <button type="button" class="mode-button active" data-mode="official">Official Value</button>
-          <button type="button" class="mode-button" data-mode="estimate">Model Estimate</button>
-          <button type="button" class="mode-button" data-mode="gap">Gap (%)</button>
+        <div class="toolbar-controls">
+          <label class="geography-control" for="geographySelect">
+            Geography
+            <select id="geographySelect">
+              <option value="citywide">Citywide</option>
+            </select>
+          </label>
+          <div class="mode-toggle" aria-label="Map value mode">
+            <button type="button" class="mode-button active" data-mode="official">Official Value</button>
+            <button type="button" class="mode-button" data-mode="estimate">Model Estimate</button>
+            <button type="button" class="mode-button" data-mode="gap">Gap (%)</button>
+          </div>
         </div>
       </div>
       <div id="map"></div>
@@ -38,12 +46,24 @@
 
         <dl id="citywideSummary" class="summary-grid">
           <div>
-            <dt>Records in map asset</dt>
+            <dt>Geography</dt>
+            <dd id="geographyText">Citywide</dd>
+          </div>
+          <div>
+            <dt>Records</dt>
             <dd id="recordCountText">-</dd>
           </div>
           <div>
-            <dt>Default field</dt>
-            <dd id="defaultFieldText">-</dd>
+            <dt>Median official</dt>
+            <dd id="medianOfficialText">-</dd>
+          </div>
+          <div>
+            <dt>Median model</dt>
+            <dd id="medianModelText">-</dd>
+          </div>
+          <div>
+            <dt>Map mode</dt>
+            <dd id="mapModeText">Official Value</dd>
           </div>
         </dl>
 
@@ -83,10 +103,31 @@
             <dt>Gap</dt>
             <dd id="selectedGapValue">-</dd>
           </div>
+          <div>
+            <dt>Official percentile citywide</dt>
+            <dd id="selectedOfficialCitywidePercentile">-</dd>
+          </div>
+          <div>
+            <dt>Official percentile in ZIP</dt>
+            <dd id="selectedOfficialZipPercentile">-</dd>
+          </div>
+          <div>
+            <dt>Model percentile citywide</dt>
+            <dd id="selectedModelCitywidePercentile">-</dd>
+          </div>
+          <div>
+            <dt>Model percentile in ZIP</dt>
+            <dd id="selectedModelZipPercentile">-</dd>
+          </div>
         </dl>
         <p class="sidebar-copy">
           The map shows one value dimension at a time. Official values and model estimates are separated so reviewers can compare them deliberately.
         </p>
+        <div class="chart-card">
+          <h3>Assessment history</h3>
+          <p id="selectedHistoryHelper" class="helper-text">Loading assessment history...</p>
+          <div id="selectedHistoryChart" class="mini-chart"></div>
+        </div>
       </section>
     </aside>
   </main>

--- a/ui/reviewer/main.js
+++ b/ui/reviewer/main.js
@@ -13,13 +13,22 @@ const DEFAULT_TILE_URL = `${PUBLIC_BASE_URL}/tiles/properties/{z}/{x}/{y}.pbf`;
 const DEFAULT_TILE_LAYER = "property_tile_info";
 const MAIN_DISPLAY_MAX = 2500000;
 const MAIN_DISPLAY_BIN_SIZE = 100000;
-const ZIP_DETAIL_MIN_ZOOM = 14;
-const VALUE_COLORS = ["#eff6ff", "#bfdbfe", "#93c5fd", "#60a5fa", "#2563eb", "#1e3a8a"];
+const VALUE_COLORS = [
+  "#eff6ff",
+  "#dbeafe",
+  "#bfdbfe",
+  "#93c5fd",
+  "#60a5fa",
+  "#2563eb",
+  "#1e3a8a",
+];
 const GAP_UNAVAILABLE_COLOR = "#d9dde5";
 const GAP_BINS = [
   { max: -75, label: "&le; -75%", color: "#53627f" },
-  { min: -75, max: -25, label: "-75% to -25%", color: "#8798b3" },
-  { min: -25, max: 25, label: "-25% to +25%", color: "#d8dee9" },
+  { min: -75, max: -60, label: "-75% to -60%", color: "#7183a3" },
+  { min: -60, max: -45, label: "-60% to -45%", color: "#9caac2" },
+  { min: -45, max: -25, label: "-45% to -25%", color: "#c0c9d8" },
+  { min: -25, max: 25, label: "-25% to +25%", color: "#e5e7eb" },
   { min: 25, max: 75, label: "+25% to +75%", color: "#c99a5c" },
   { min: 75, label: "&gt; +75%", color: "#87552c" },
 ];
@@ -143,26 +152,8 @@ function setStatus(message = "") {
   document.getElementById("mapStatus").textContent = message;
 }
 
-function shouldApplyZipDetailTreatment() {
-  return activeGeography !== "citywide" && map.getZoom() >= ZIP_DETAIL_MIN_ZOOM;
-}
-
-function updateZipZoomMessage() {
-  const message = document.getElementById("zipZoomMessage");
-  const shouldShow =
-    activeGeography !== "citywide" && map.getZoom() < ZIP_DETAIL_MIN_ZOOM;
-
-  message.hidden = !shouldShow;
-}
-
-function ensureZipDetailZoom() {
-  if (activeGeography === "citywide" || !map) {
-    return;
-  }
-
-  if (map.getZoom() < ZIP_DETAIL_MIN_ZOOM) {
-    map.setZoom(ZIP_DETAIL_MIN_ZOOM);
-  }
+function normalizeZip(value) {
+  return String(value ?? "").trim().slice(0, 5);
 }
 
 function getTilePropertyValue(properties, modeName = activeMode) {
@@ -196,6 +187,30 @@ function getBreakpoints(modeName = activeMode) {
     .sort((left, right) => left - right);
 }
 
+function getValueClassBreaks(modeName = activeMode) {
+  const breakpoints = getBreakpoints(modeName);
+
+  if (breakpoints.length >= VALUE_COLORS.length + 1) {
+    return breakpoints.slice(0, VALUE_COLORS.length + 1);
+  }
+
+  if (breakpoints.length >= 2) {
+    const min = breakpoints[0];
+    const max = breakpoints[breakpoints.length - 1];
+    const step = (max - min) / VALUE_COLORS.length;
+
+    return Array.from(
+      { length: VALUE_COLORS.length + 1 },
+      (_item, index) => min + step * index,
+    );
+  }
+
+  return Array.from(
+    { length: VALUE_COLORS.length + 1 },
+    (_item, index) => index * 250000,
+  );
+}
+
 function getGapBin(value) {
   const number = Number(value);
 
@@ -213,24 +228,25 @@ function getGapBin(value) {
 function getColor(value, modeName = activeMode) {
   const number = Number(value);
   const mode = modes[modeName];
-  const breakpoints = getBreakpoints(modeName);
 
   if (modeName === "gap") {
     const gapBin = getGapBin(number);
     return gapBin ? gapBin.color : GAP_UNAVAILABLE_COLOR;
   }
 
+  const classBreaks = getValueClassBreaks(modeName);
+
   if (!Number.isFinite(number)) {
     return "#cfd6df";
   }
 
-  if (breakpoints.length < 2) {
+  if (classBreaks.length < 2) {
     return mode.colors[Math.floor(mode.colors.length / 2)];
   }
 
   let index = 0;
-  for (let i = 1; i < breakpoints.length; i += 1) {
-    if (number >= breakpoints[i]) {
+  for (let i = 1; i < classBreaks.length - 1; i += 1) {
+    if (number >= classBreaks[i]) {
       index = i;
     }
   }
@@ -241,7 +257,8 @@ function getColor(value, modeName = activeMode) {
 function styleFeature(properties) {
   const value = getTilePropertyValue(properties);
   const outsideSelectedZip =
-    shouldApplyZipDetailTreatment() && properties.zip_code !== activeGeography;
+    activeGeography !== "citywide" &&
+    normalizeZip(properties.zip_code) !== normalizeZip(activeGeography);
   const gapUnavailable = activeMode === "gap" && !Number.isFinite(Number(value));
 
   return {
@@ -269,7 +286,7 @@ function getTileConfig() {
 
 function renderLegend() {
   const mode = modes[activeMode];
-  const breakpoints = getBreakpoints();
+  const valueClassBreaks = getValueClassBreaks();
 
   if (!legendControl) {
     legendControl = L.control({ position: "bottomright" });
@@ -292,16 +309,17 @@ function renderLegend() {
             </div>
           `,
         )
-      : breakpoints.slice(0, mode.colors.length).map((breakpoint, index) => {
-          const next = breakpoints[index + 1];
+      : mode.colors.map((color, index) => {
+          const lower = valueClassBreaks[index];
+          const upper = valueClassBreaks[index + 1];
           const label =
-            next === undefined
-              ? `${formatModeValue(breakpoint)}+`
-              : `${formatModeValue(breakpoint)} to ${formatModeValue(next)}`;
+            index === mode.colors.length - 1
+              ? `${formatModeValue(lower)}+`
+              : `${formatModeValue(lower)} to ${formatModeValue(upper)}`;
 
           return `
             <div class="legend-row">
-              <span style="background:${mode.colors[index]}"></span>
+              <span style="background:${color}"></span>
               <em>${label}</em>
             </div>
           `;
@@ -334,6 +352,10 @@ function renderTileLayer() {
   propertyTileLayer.on("mouseover", (event) => {
     const properties = event.layer.properties;
     const value = getTilePropertyValue(properties);
+    const gapLine =
+      activeMode === "gap"
+        ? `<br>Gap: ${Number.isFinite(Number(value)) ? formatGapPercent(value) : "unavailable"}`
+        : "";
 
     hoverPopup = L.popup({
       closeButton: false,
@@ -345,8 +367,7 @@ function renderTileLayer() {
         <strong>${properties.address || "Address not available"}</strong><br>
         ZIP: ${properties.zip_code || "N/A"}<br>
         Official: ${formatMoney(properties.tax_year_assessed_value)}<br>
-        Estimate: ${formatMoney(properties.current_assessed_value)}<br>
-        ${modes[activeMode].label}: ${formatModeValue(value)}
+        Estimate: ${formatMoney(properties.current_assessed_value)}${gapLine}
       `)
       .openOn(map);
   });
@@ -362,8 +383,8 @@ function renderTileLayer() {
     const properties = event.layer.properties;
 
     if (
-      shouldApplyZipDetailTreatment() &&
-      properties.zip_code !== activeGeography
+      activeGeography !== "citywide" &&
+      normalizeZip(properties.zip_code) !== normalizeZip(activeGeography)
     ) {
       setStatus(`That property is outside ZIP ${activeGeography}.`);
       return;
@@ -866,7 +887,6 @@ async function initializeDashboard() {
     updateSummary();
     updateCharts();
     renderTileLayer();
-    updateZipZoomMessage();
     setStatus("");
   } catch (error) {
     setStatus(
@@ -878,7 +898,6 @@ async function initializeDashboard() {
     zipContext = zipContext || { areas: {} };
     updateSummary();
     renderTileLayer();
-    updateZipZoomMessage();
   }
 }
 
@@ -892,26 +911,18 @@ document.addEventListener("DOMContentLoaded", () => {
 
   document.getElementById("geographySelect").addEventListener("change", (event) => {
     activeGeography = event.target.value;
-    ensureZipDetailZoom();
     if (
       selectedProperties &&
       activeGeography !== "citywide" &&
-      selectedProperties.zip_code !== activeGeography
+      normalizeZip(selectedProperties.zip_code) !== normalizeZip(activeGeography)
     ) {
       clearSelection();
     }
     updateSummary();
     updateCharts();
-    updateZipZoomMessage();
     renderTileLayer();
   });
 
   document.getElementById("clearSelectionBtn").addEventListener("click", clearSelection);
-  map.on("zoomend", () => {
-    updateZipZoomMessage();
-    if (propertyTileLayer) {
-      renderTileLayer();
-    }
-  });
   initializeDashboard();
 });

--- a/ui/reviewer/main.js
+++ b/ui/reviewer/main.js
@@ -9,7 +9,14 @@ const DEFAULT_TILE_LAYER = "property_tile_info";
 const MAIN_DISPLAY_MAX = 2500000;
 const MAIN_DISPLAY_BIN_SIZE = 100000;
 const VALUE_COLORS = ["#eff6ff", "#bfdbfe", "#93c5fd", "#60a5fa", "#2563eb", "#1e3a8a"];
-const GAP_COLORS = ["#53627f", "#8798b3", "#d8dee9", "#e2c48f", "#c98c4a", "#87552c"];
+const GAP_UNAVAILABLE_COLOR = "#d9dde5";
+const GAP_BINS = [
+  { max: -75, label: "&le; -75%", color: "#53627f" },
+  { min: -75, max: -25, label: "-75% to -25%", color: "#8798b3" },
+  { min: -25, max: 25, label: "-25% to +25%", color: "#d8dee9" },
+  { min: 25, max: 75, label: "+25% to +75%", color: "#c99a5c" },
+  { min: 75, label: "&gt; +75%", color: "#87552c" },
+];
 
 const map = L.map("map", {
   zoomControl: true,
@@ -47,7 +54,7 @@ const modes = {
     description: "Showing percent difference between model estimate and official value.",
     field: "gap_pct",
     metadataField: "percent_change",
-    colors: GAP_COLORS,
+    colors: GAP_BINS.map((bin) => bin.color),
   },
 };
 
@@ -103,6 +110,19 @@ function formatPercent(value) {
   }).format(number);
 }
 
+function formatGapPercent(value) {
+  const number = Number(value);
+
+  if (!Number.isFinite(number)) {
+    return "Gap unavailable";
+  }
+
+  return `${new Intl.NumberFormat("en-US", {
+    minimumFractionDigits: 1,
+    maximumFractionDigits: 1,
+  }).format(number)}%`;
+}
+
 function setStatus(message = "") {
   document.getElementById("mapStatus").textContent = message;
 }
@@ -112,11 +132,15 @@ function getTilePropertyValue(properties, modeName = activeMode) {
     const official = Number(properties.tax_year_assessed_value);
     const estimate = Number(properties.current_assessed_value);
 
-    if (!Number.isFinite(official) || official === 0 || !Number.isFinite(estimate)) {
+    if (
+      !Number.isFinite(official) ||
+      official < 10000 ||
+      !Number.isFinite(estimate)
+    ) {
       return null;
     }
 
-    return (estimate - official) / official;
+    return ((estimate - official) / official) * 100;
   }
 
   return Number(properties[modes[modeName].field]);
@@ -139,6 +163,11 @@ function getColor(value, modeName = activeMode) {
   const mode = modes[modeName];
   const breakpoints = getBreakpoints(modeName);
 
+  if (modeName === "gap") {
+    const gapBin = getGapBin(number);
+    return gapBin ? gapBin.color : GAP_UNAVAILABLE_COLOR;
+  }
+
   if (!Number.isFinite(number)) {
     return "#cfd6df";
   }
@@ -157,11 +186,28 @@ function getColor(value, modeName = activeMode) {
   return mode.colors[Math.min(index, mode.colors.length - 1)];
 }
 
+function getGapBin(value) {
+  const number = Number(value);
+
+  if (!Number.isFinite(number)) {
+    return null;
+  }
+
+  return GAP_BINS.find((bin) => {
+    const aboveMin = bin.min === undefined || number > bin.min;
+    const belowMax = bin.max === undefined || number <= bin.max;
+    return aboveMin && belowMax;
+  });
+}
+
 function styleFeature(properties) {
+  const value = getTilePropertyValue(properties);
+  const gapUnavailable = activeMode === "gap" && !Number.isFinite(Number(value));
+
   return {
     fill: true,
-    fillColor: getColor(getTilePropertyValue(properties)),
-    fillOpacity: 0.72,
+    fillColor: getColor(value),
+    fillOpacity: gapUnavailable ? 0.25 : 0.72,
     color: "#ffffff",
     opacity: 0.35,
     weight: 0.45,
@@ -169,7 +215,7 @@ function styleFeature(properties) {
 }
 
 function formatModeValue(value, modeName = activeMode) {
-  return modeName === "gap" ? formatPercent(value) : formatMoney(value);
+  return modeName === "gap" ? formatGapPercent(value) : formatMoney(value);
 }
 
 function getTileConfig() {
@@ -196,20 +242,30 @@ function renderLegend() {
   }
 
   const legend = document.getElementById("mapLegend");
-  const labels = breakpoints.slice(0, mode.colors.length).map((breakpoint, index) => {
-    const next = breakpoints[index + 1];
-    const label =
-      next === undefined
-        ? `${formatModeValue(breakpoint)}+`
-        : `${formatModeValue(breakpoint)} to ${formatModeValue(next)}`;
+  const labels =
+    activeMode === "gap"
+      ? GAP_BINS.map(
+          (bin) => `
+            <div class="legend-row">
+              <span style="background:${bin.color}"></span>
+              <em>${bin.label}</em>
+            </div>
+          `,
+        )
+      : breakpoints.slice(0, mode.colors.length).map((breakpoint, index) => {
+          const next = breakpoints[index + 1];
+          const label =
+            next === undefined
+              ? `${formatModeValue(breakpoint)}+`
+              : `${formatModeValue(breakpoint)} to ${formatModeValue(next)}`;
 
-    return `
-      <div class="legend-row">
-        <span style="background:${mode.colors[index]}"></span>
-        <em>${label}</em>
-      </div>
-    `;
-  });
+          return `
+            <div class="legend-row">
+              <span style="background:${mode.colors[index]}"></span>
+              <em>${label}</em>
+            </div>
+          `;
+        });
 
   legend.innerHTML = `
     <strong>${mode.label}</strong>
@@ -285,7 +341,11 @@ function calculateGapValue(properties) {
   const official = Number(properties.tax_year_assessed_value);
   const estimate = Number(properties.current_assessed_value);
 
-  if (!Number.isFinite(official) || !Number.isFinite(estimate)) {
+  if (
+    !Number.isFinite(official) ||
+    official < 10000 ||
+    !Number.isFinite(estimate)
+  ) {
     return null;
   }
 
@@ -296,11 +356,11 @@ function calculateGapPercent(properties) {
   const official = Number(properties.tax_year_assessed_value);
   const gap = calculateGapValue(properties);
 
-  if (!Number.isFinite(official) || official === 0 || !Number.isFinite(gap)) {
+  if (!Number.isFinite(official) || official < 10000 || !Number.isFinite(gap)) {
     return null;
   }
 
-  return gap / official;
+  return (gap / official) * 100;
 }
 
 function renderSelectedProperty(properties) {
@@ -317,7 +377,7 @@ function renderSelectedProperty(properties) {
     properties.current_assessed_value,
   );
   document.getElementById("selectedGapValue").textContent =
-    `${formatMoney(calculateGapValue(properties))} (${formatPercent(calculateGapPercent(properties))})`;
+    `${formatMoney(calculateGapValue(properties))} (${formatGapPercent(calculateGapPercent(properties))})`;
 }
 
 function clearSelection() {

--- a/ui/reviewer/main.js
+++ b/ui/reviewer/main.js
@@ -3,6 +3,11 @@ const PUBLIC_BASE_URL =
 const MAP_STYLE_METADATA_URL = `${PUBLIC_BASE_URL}/configs/map_style_metadata.json`;
 const TAX_YEAR_ASSESSMENT_BINS_URL = `${PUBLIC_BASE_URL}/configs/tax_year_assessment_bins.json`;
 const CURRENT_ASSESSMENT_BINS_URL = `${PUBLIC_BASE_URL}/configs/current_assessment_bins.json`;
+const ZIP_ASSESSMENT_CONTEXT_URL = `${PUBLIC_BASE_URL}/configs/zip_assessment_context.json`;
+const PROPERTY_LOOKUP_API_URL =
+  window.PROPERTY_LOOKUP_API_URL ||
+  new URLSearchParams(window.location.search).get("lookup_api_url") ||
+  "https://property-assessment-lookup-bl43esqwsa-uk.a.run.app";
 
 const DEFAULT_TILE_URL = `${PUBLIC_BASE_URL}/tiles/properties/{z}/{x}/{y}.pbf`;
 const DEFAULT_TILE_LAYER = "property_tile_info";
@@ -27,12 +32,19 @@ L.tileLayer("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png", {
 }).addTo(map);
 
 let metadata = null;
+let zipContext = null;
 let activeMode = "official";
+let activeGeography = "citywide";
 let propertyTileLayer = null;
 let hoverPopup = null;
 let officialChart = null;
 let modelChart = null;
+let selectedHistoryChart = null;
 let legendControl = null;
+let citywideOfficialRows = [];
+let citywideModelRows = [];
+let selectedProperties = null;
+let selectedLookupPayload = null;
 
 const modes = {
   official: {
@@ -97,17 +109,20 @@ function formatNumber(value) {
   return new Intl.NumberFormat("en-US").format(Math.round(number));
 }
 
-function formatPercent(value) {
+function formatPercentile(value) {
   const number = Number(value);
 
   if (!Number.isFinite(number)) {
-    return "N/A";
+    return "-";
   }
 
-  return new Intl.NumberFormat("en-US", {
-    style: "percent",
-    maximumFractionDigits: 1,
-  }).format(number);
+  const rounded = Math.round(number);
+  const suffix =
+    rounded % 100 >= 11 && rounded % 100 <= 13
+      ? "th"
+      : { 1: "st", 2: "nd", 3: "rd" }[rounded % 10] || "th";
+
+  return `${rounded}${suffix}`;
 }
 
 function formatGapPercent(value) {
@@ -158,6 +173,20 @@ function getBreakpoints(modeName = activeMode) {
     .sort((left, right) => left - right);
 }
 
+function getGapBin(value) {
+  const number = Number(value);
+
+  if (!Number.isFinite(number)) {
+    return null;
+  }
+
+  return GAP_BINS.find((bin) => {
+    const aboveMin = bin.min === undefined || number > bin.min;
+    const belowMax = bin.max === undefined || number <= bin.max;
+    return aboveMin && belowMax;
+  });
+}
+
 function getColor(value, modeName = activeMode) {
   const number = Number(value);
   const mode = modes[modeName];
@@ -186,30 +215,18 @@ function getColor(value, modeName = activeMode) {
   return mode.colors[Math.min(index, mode.colors.length - 1)];
 }
 
-function getGapBin(value) {
-  const number = Number(value);
-
-  if (!Number.isFinite(number)) {
-    return null;
-  }
-
-  return GAP_BINS.find((bin) => {
-    const aboveMin = bin.min === undefined || number > bin.min;
-    const belowMax = bin.max === undefined || number <= bin.max;
-    return aboveMin && belowMax;
-  });
-}
-
 function styleFeature(properties) {
   const value = getTilePropertyValue(properties);
+  const outsideSelectedZip =
+    activeGeography !== "citywide" && properties.zip_code !== activeGeography;
   const gapUnavailable = activeMode === "gap" && !Number.isFinite(Number(value));
 
   return {
     fill: true,
-    fillColor: getColor(value),
-    fillOpacity: gapUnavailable ? 0.25 : 0.72,
+    fillColor: outsideSelectedZip ? "#d9dde5" : getColor(value),
+    fillOpacity: outsideSelectedZip || gapUnavailable ? 0.2 : 0.72,
     color: "#ffffff",
-    opacity: 0.35,
+    opacity: outsideSelectedZip ? 0.1 : 0.35,
     weight: 0.45,
   };
 }
@@ -303,6 +320,7 @@ function renderTileLayer() {
       .setLatLng(event.latlng)
       .setContent(`
         <strong>${properties.address || "Address not available"}</strong><br>
+        ZIP: ${properties.zip_code || "N/A"}<br>
         Official: ${formatMoney(properties.tax_year_assessed_value)}<br>
         Estimate: ${formatMoney(properties.current_assessed_value)}<br>
         ${modes[activeMode].label}: ${formatModeValue(value)}
@@ -318,18 +336,283 @@ function renderTileLayer() {
   });
 
   propertyTileLayer.on("click", (event) => {
-    renderSelectedProperty(event.layer.properties);
+    const properties = event.layer.properties;
+
+    if (activeGeography !== "citywide" && properties.zip_code !== activeGeography) {
+      setStatus(`That property is outside ZIP ${activeGeography}.`);
+      return;
+    }
+
+    renderSelectedProperty(properties);
   });
 
   propertyTileLayer.addTo(map);
   renderLegend();
 }
 
+function normalizeBinRows(rows) {
+  return rows
+    .map((row) => ({
+      lowerBound: Number(row.lower_bound),
+      upperBound: row.upper_bound === null ? null : Number(row.upper_bound),
+      propertyCount: Number(row.property_count),
+    }))
+    .filter(
+      (row) =>
+        Number.isFinite(row.lowerBound) && Number.isFinite(row.propertyCount),
+    )
+    .sort((left, right) => left.lowerBound - right.lowerBound);
+}
+
+function buildDisplayBins(rows) {
+  const bins = [];
+
+  for (
+    let lowerBound = 0;
+    lowerBound < MAIN_DISPLAY_MAX;
+    lowerBound += MAIN_DISPLAY_BIN_SIZE
+  ) {
+    bins.push({
+      lowerBound,
+      upperBound: lowerBound + MAIN_DISPLAY_BIN_SIZE,
+      propertyCount: 0,
+      category: `${formatCompactMoney(lowerBound)} to ${formatCompactMoney(
+        lowerBound + MAIN_DISPLAY_BIN_SIZE,
+      )}`,
+      label:
+        lowerBound === 0 || lowerBound % 500000 === 0
+          ? formatCompactMoney(lowerBound)
+          : "",
+    });
+  }
+
+  bins.push({
+    lowerBound: MAIN_DISPLAY_MAX,
+    upperBound: null,
+    propertyCount: 0,
+    category: ">$2.5M",
+    label: ">$2.5M",
+  });
+
+  rows.forEach((row) => {
+    if (row.lowerBound >= MAIN_DISPLAY_MAX || row.upperBound > MAIN_DISPLAY_MAX) {
+      bins[bins.length - 1].propertyCount += row.propertyCount;
+      return;
+    }
+
+    const index = Math.floor(row.lowerBound / MAIN_DISPLAY_BIN_SIZE);
+    if (bins[index]) {
+      bins[index].propertyCount += row.propertyCount;
+    }
+  });
+
+  return bins;
+}
+
+function getMarkerCategory(rows, selectedValue) {
+  const value = Number(selectedValue);
+
+  if (!Number.isFinite(value)) {
+    return null;
+  }
+
+  const match = rows.find(
+    (row) =>
+      value >= row.lowerBound &&
+      (row.upperBound === null || value < row.upperBound),
+  );
+
+  return match?.category || null;
+}
+
+function computeMedianFromBins(rows) {
+  const total = rows.reduce((sum, row) => sum + row.propertyCount, 0);
+  let cumulative = 0;
+
+  if (total === 0) {
+    return null;
+  }
+
+  for (const row of rows) {
+    cumulative += row.propertyCount;
+    if (cumulative >= total / 2) {
+      return row.lowerBound + MAIN_DISPLAY_BIN_SIZE / 2;
+    }
+  }
+
+  return null;
+}
+
+function getAreaData() {
+  if (activeGeography !== "citywide") {
+    const area = zipContext?.areas?.[activeGeography];
+
+    return {
+      label: area?.label || `ZIP ${activeGeography}`,
+      recordCount: area?.record_count,
+      officialMedian: area?.official?.approx_median,
+      modelMedian: area?.model?.approx_median,
+      officialRows: normalizeBinRows(area?.official?.bins || []),
+      modelRows: normalizeBinRows(area?.model?.bins || []),
+    };
+  }
+
+  return {
+    label: "Citywide",
+    recordCount: metadata?.record_count,
+    officialMedian: computeMedianFromBins(citywideOfficialRows),
+    modelMedian: computeMedianFromBins(citywideModelRows),
+    officialRows: citywideOfficialRows,
+    modelRows: citywideModelRows,
+  };
+}
+
+function renderDistributionChart(chartElementId, rows, chartRef, selectedValue) {
+  const chartElement = document.getElementById(chartElementId);
+  const displayRows = buildDisplayBins(rows);
+  const markerCategory = getMarkerCategory(displayRows, selectedValue);
+  const labelByCategory = Object.fromEntries(
+    displayRows.map((row) => [row.category, row.label]),
+  );
+
+  if (chartRef) {
+    chartRef.destroy();
+  }
+
+  const chart = new window.ApexCharts(chartElement, {
+    chart: {
+      type: "bar",
+      height: 220,
+      toolbar: {
+        show: false,
+      },
+    },
+    annotations: {
+      xaxis: markerCategory
+        ? [
+            {
+              x: markerCategory,
+              borderColor: "#0f2438",
+              label: {
+                text: "Selected",
+                style: {
+                  background: "#0f2438",
+                  color: "#ffffff",
+                },
+              },
+            },
+          ]
+        : [],
+    },
+    series: [
+      {
+        name: "Properties",
+        data: displayRows.map((row) => row.propertyCount),
+      },
+    ],
+    colors: ["#1f5f99"],
+    dataLabels: {
+      enabled: false,
+    },
+    plotOptions: {
+      bar: {
+        columnWidth: "85%",
+      },
+    },
+    grid: {
+      borderColor: "#d9dde5",
+      strokeDashArray: 3,
+    },
+    xaxis: {
+      categories: displayRows.map((row) => row.category),
+      labels: {
+        rotate: 0,
+        hideOverlappingLabels: true,
+        formatter: (value) => labelByCategory[value] || "",
+      },
+    },
+    yaxis: {
+      labels: {
+        formatter: (value) => formatNumber(value),
+      },
+    },
+    tooltip: {
+      x: {
+        formatter: (value) => value,
+      },
+      y: {
+        formatter: (value) => `${formatNumber(value)} properties`,
+      },
+    },
+  });
+
+  chart.render();
+  return chart;
+}
+
+function updateSummary() {
+  const area = getAreaData();
+
+  document.getElementById("geographyText").textContent = area.label;
+  document.getElementById("recordCountText").textContent = formatNumber(
+    area.recordCount,
+  );
+  document.getElementById("medianOfficialText").textContent = formatMoney(
+    area.officialMedian,
+  );
+  document.getElementById("medianModelText").textContent = formatMoney(
+    area.modelMedian,
+  );
+  document.getElementById("mapModeText").textContent = modes[activeMode].label;
+  document.getElementById("modeLabel").textContent = modes[activeMode].description;
+}
+
+function updateCharts() {
+  if (!window.ApexCharts) {
+    document.getElementById("officialChartHelper").textContent =
+      "Chart library failed to load.";
+    document.getElementById("modelChartHelper").textContent =
+      "Chart library failed to load.";
+    return;
+  }
+
+  const area = getAreaData();
+  officialChart = renderDistributionChart(
+    "officialDistributionChart",
+    area.officialRows,
+    officialChart,
+    selectedProperties?.tax_year_assessed_value,
+  );
+  modelChart = renderDistributionChart(
+    "modelDistributionChart",
+    area.modelRows,
+    modelChart,
+    selectedProperties?.current_assessed_value,
+  );
+
+  document.getElementById("officialChartHelper").textContent =
+    `${area.label}; values above $2.5M are grouped.`;
+  document.getElementById("modelChartHelper").textContent =
+    `${area.label}; values above $2.5M are grouped.`;
+}
+
+function populateGeographySelect() {
+  const select = document.getElementById("geographySelect");
+  const zipCodes = Object.keys(zipContext?.areas || {}).sort();
+
+  zipCodes.forEach((zipCode) => {
+    const option = document.createElement("option");
+    option.value = zipCode;
+    option.textContent = `ZIP ${zipCode}`;
+    select.appendChild(option);
+  });
+}
+
 function renderModeControls() {
   document.querySelectorAll(".mode-button").forEach((button) => {
     button.classList.toggle("active", button.dataset.mode === activeMode);
   });
-  document.getElementById("modeLabel").textContent = modes[activeMode].description;
+  updateSummary();
   renderLegend();
 
   if (propertyTileLayer) {
@@ -363,7 +646,105 @@ function calculateGapPercent(properties) {
   return (gap / official) * 100;
 }
 
+function destroySelectedHistoryChart() {
+  if (selectedHistoryChart) {
+    selectedHistoryChart.destroy();
+    selectedHistoryChart = null;
+  }
+}
+
+function renderSelectedHistory(history) {
+  const helper = document.getElementById("selectedHistoryHelper");
+  const chartElement = document.getElementById("selectedHistoryChart");
+  destroySelectedHistoryChart();
+
+  if (!Array.isArray(history) || history.length === 0 || !window.ApexCharts) {
+    helper.textContent = "Assessment history unavailable.";
+    chartElement.innerHTML = "";
+    return;
+  }
+
+  helper.textContent = "Official assessed values by tax year.";
+  chartElement.innerHTML = "";
+
+  selectedHistoryChart = new window.ApexCharts(chartElement, {
+    chart: {
+      type: "line",
+      height: 180,
+      toolbar: {
+        show: false,
+      },
+    },
+    series: [
+      {
+        name: "Official assessed value",
+        data: history.map((item) => Number(item.assessed_value)),
+      },
+    ],
+    colors: ["#1f5f99"],
+    stroke: {
+      width: 3,
+    },
+    markers: {
+      size: 3,
+    },
+    xaxis: {
+      categories: history.map((item) => String(item.tax_year)),
+    },
+    yaxis: {
+      labels: {
+        formatter: (value) => formatCompactMoney(value),
+      },
+    },
+    tooltip: {
+      y: {
+        formatter: (value) => formatMoney(value),
+      },
+    },
+  });
+
+  selectedHistoryChart.render();
+}
+
+async function loadSelectedLookup(propertyId) {
+  try {
+    const url = new URL(PROPERTY_LOOKUP_API_URL, window.location.origin);
+    url.searchParams.set("property_id", propertyId);
+
+    const response = await fetch(url);
+    const payload = await response.json();
+
+    if (!response.ok || !payload.ok) {
+      throw new Error(payload.error || "Assessment history unavailable.");
+    }
+
+    selectedLookupPayload = payload;
+    renderSelectedPercentiles();
+    renderSelectedHistory(payload.history || []);
+  } catch (error) {
+    selectedLookupPayload = null;
+    renderSelectedPercentiles();
+    renderSelectedHistory([]);
+  }
+}
+
+function renderSelectedPercentiles() {
+  const citywide = selectedLookupPayload?.context?.citywide || {};
+  const zip = selectedLookupPayload?.context?.zip || {};
+
+  document.getElementById("selectedOfficialCitywidePercentile").textContent =
+    formatPercentile(citywide.official_percentile);
+  document.getElementById("selectedOfficialZipPercentile").textContent =
+    formatPercentile(zip.official_percentile);
+  document.getElementById("selectedModelCitywidePercentile").textContent =
+    formatPercentile(citywide.model_percentile);
+  document.getElementById("selectedModelZipPercentile").textContent =
+    formatPercentile(zip.model_percentile);
+}
+
 function renderSelectedProperty(properties) {
+  selectedProperties = properties;
+  selectedLookupPayload = null;
   document.getElementById("citywidePanel").hidden = true;
   document.getElementById("selectedPanel").hidden = false;
   document.getElementById("selectedAddress").textContent =
@@ -378,129 +759,24 @@ function renderSelectedProperty(properties) {
   );
   document.getElementById("selectedGapValue").textContent =
     `${formatMoney(calculateGapValue(properties))} (${formatGapPercent(calculateGapPercent(properties))})`;
+  document.getElementById("selectedHistoryHelper").textContent =
+    "Loading assessment history...";
+  document.getElementById("selectedHistoryChart").innerHTML = "";
+  renderSelectedPercentiles();
+  updateCharts();
+  loadSelectedLookup(properties.property_id);
 }
 
 function clearSelection() {
+  selectedProperties = null;
+  selectedLookupPayload = null;
+  destroySelectedHistoryChart();
   document.getElementById("citywidePanel").hidden = false;
   document.getElementById("selectedPanel").hidden = true;
+  updateCharts();
 }
 
-function normalizeBinRows(rows) {
-  return rows
-    .map((row) => ({
-      lowerBound: Number(row.lower_bound),
-      upperBound: Number(row.upper_bound),
-      propertyCount: Number(row.property_count),
-    }))
-    .filter(
-      (row) =>
-        Number.isFinite(row.lowerBound) &&
-        Number.isFinite(row.upperBound) &&
-        Number.isFinite(row.propertyCount),
-    )
-    .sort((left, right) => left.lowerBound - right.lowerBound);
-}
-
-function buildDisplayBins(rows) {
-  const bins = [];
-
-  for (let lowerBound = 0; lowerBound < MAIN_DISPLAY_MAX; lowerBound += MAIN_DISPLAY_BIN_SIZE) {
-    bins.push({
-      lowerBound,
-      upperBound: lowerBound + MAIN_DISPLAY_BIN_SIZE,
-      propertyCount: 0,
-      label: lowerBound === 0 || lowerBound % 500000 === 0 ? formatCompactMoney(lowerBound) : "",
-    });
-  }
-
-  bins.push({
-    lowerBound: MAIN_DISPLAY_MAX,
-    upperBound: null,
-    propertyCount: 0,
-    label: ">$2.5M",
-  });
-
-  rows.forEach((row) => {
-    if (row.lowerBound >= MAIN_DISPLAY_MAX || row.upperBound > MAIN_DISPLAY_MAX) {
-      bins[bins.length - 1].propertyCount += row.propertyCount;
-      return;
-    }
-
-    const index = Math.floor(row.lowerBound / MAIN_DISPLAY_BIN_SIZE);
-    if (bins[index]) {
-      bins[index].propertyCount += row.propertyCount;
-    }
-  });
-
-  return bins;
-}
-
-function renderDistributionChart(chartElementId, rows, chartRef) {
-  const chartElement = document.getElementById(chartElementId);
-
-  if (chartRef) {
-    chartRef.destroy();
-  }
-
-  const chart = new window.ApexCharts(chartElement, {
-    chart: {
-      type: "bar",
-      height: 220,
-      toolbar: {
-        show: false,
-      },
-    },
-    series: [
-      {
-        name: "Properties",
-        data: rows.map((row) => row.propertyCount),
-      },
-    ],
-    colors: ["#1f5f99"],
-    dataLabels: {
-      enabled: false,
-    },
-    plotOptions: {
-      bar: {
-        columnWidth: "85%",
-      },
-    },
-    grid: {
-      borderColor: "#d9dde5",
-      strokeDashArray: 3,
-    },
-    xaxis: {
-      categories: rows.map((row) => row.label),
-      labels: {
-        rotate: 0,
-        hideOverlappingLabels: true,
-      },
-    },
-    yaxis: {
-      labels: {
-        formatter: (value) => formatNumber(value),
-      },
-    },
-    tooltip: {
-      y: {
-        formatter: (value) => `${formatNumber(value)} properties`,
-      },
-    },
-  });
-
-  chart.render();
-  return chart;
-}
-
-async function loadDistributionCharts() {
-  if (!window.ApexCharts) {
-    document.getElementById("officialChartHelper").textContent =
-      "Chart library failed to load.";
-    document.getElementById("modelChartHelper").textContent =
-      "Chart library failed to load.";
-    return;
-  }
-
+async function loadDistributionInputs() {
   const [officialResponse, modelResponse] = await Promise.all([
     fetch(TAX_YEAR_ASSESSMENT_BINS_URL),
     fetch(CURRENT_ASSESSMENT_BINS_URL),
@@ -519,46 +795,30 @@ async function loadDistributionCharts() {
     .map((row) => Number(row.tax_year))
     .filter((taxYear) => Number.isFinite(taxYear));
   const latestTaxYear = Math.max(...taxYears);
-  const latestOfficialRows = officialPayload.filter(
-    (row) => Number(row.tax_year) === latestTaxYear,
+  citywideOfficialRows = normalizeBinRows(
+    officialPayload.filter((row) => Number(row.tax_year) === latestTaxYear),
   );
-
-  officialChart = renderDistributionChart(
-    "officialDistributionChart",
-    buildDisplayBins(normalizeBinRows(latestOfficialRows)),
-    officialChart,
-  );
-  modelChart = renderDistributionChart(
-    "modelDistributionChart",
-    buildDisplayBins(normalizeBinRows(modelPayload)),
-    modelChart,
-  );
-
-  document.getElementById("officialChartHelper").textContent =
-    `Latest tax year ${latestTaxYear}; values above $2.5M are grouped.`;
-  document.getElementById("modelChartHelper").textContent =
-    "Current model estimates; values above $2.5M are grouped.";
-}
-
-function renderMetadataSummary() {
-  document.getElementById("recordCountText").textContent = formatNumber(
-    metadata?.record_count,
-  );
-  document.getElementById("defaultFieldText").textContent =
-    metadata?.default_style_field || "current_assessed_value";
+  citywideModelRows = normalizeBinRows(modelPayload);
 }
 
 async function initializeDashboard() {
   try {
-    const metadataResponse = await fetch(MAP_STYLE_METADATA_URL);
-    if (!metadataResponse.ok) {
-      throw new Error("Unable to load map style metadata.");
+    const [metadataResponse, zipResponse] = await Promise.all([
+      fetch(MAP_STYLE_METADATA_URL),
+      fetch(ZIP_ASSESSMENT_CONTEXT_URL),
+    ]);
+
+    if (!metadataResponse.ok || !zipResponse.ok) {
+      throw new Error("Unable to load public dashboard assets.");
     }
 
     metadata = await metadataResponse.json();
-    renderMetadataSummary();
+    zipContext = await zipResponse.json();
+    await loadDistributionInputs();
+    populateGeographySelect();
+    updateSummary();
+    updateCharts();
     renderTileLayer();
-    await loadDistributionCharts();
     setStatus("");
   } catch (error) {
     setStatus(
@@ -567,7 +827,8 @@ async function initializeDashboard() {
         : "Unable to load public dashboard assets.",
     );
     metadata = metadata || {};
-    renderMetadataSummary();
+    zipContext = zipContext || { areas: {} };
+    updateSummary();
     renderTileLayer();
   }
 }
@@ -578,6 +839,20 @@ document.addEventListener("DOMContentLoaded", () => {
       activeMode = button.dataset.mode;
       renderModeControls();
     });
+  });
+
+  document.getElementById("geographySelect").addEventListener("change", (event) => {
+    activeGeography = event.target.value;
+    if (
+      selectedProperties &&
+      activeGeography !== "citywide" &&
+      selectedProperties.zip_code !== activeGeography
+    ) {
+      clearSelection();
+    }
+    updateSummary();
+    updateCharts();
+    renderTileLayer();
   });
 
   document.getElementById("clearSelectionBtn").addEventListener("click", clearSelection);

--- a/ui/reviewer/main.js
+++ b/ui/reviewer/main.js
@@ -14,22 +14,22 @@ const DEFAULT_TILE_LAYER = "property_tile_info";
 const MAIN_DISPLAY_MAX = 2500000;
 const MAIN_DISPLAY_BIN_SIZE = 100000;
 const VALUE_COLORS = [
-  "#eff6ff",
   "#dbeafe",
   "#bfdbfe",
   "#93c5fd",
   "#60a5fa",
+  "#3b82f6",
   "#2563eb",
   "#1e3a8a",
 ];
 const GAP_UNAVAILABLE_COLOR = "#d9dde5";
 const GAP_BINS = [
   { max: -75, label: "&le; -75%", color: "#53627f" },
-  { min: -75, max: -60, label: "-75% to -60%", color: "#7183a3" },
-  { min: -60, max: -45, label: "-60% to -45%", color: "#9caac2" },
-  { min: -45, max: -25, label: "-45% to -25%", color: "#c0c9d8" },
+  { min: -75, max: -50, label: "-75% to -50%", color: "#7183a3" },
+  { min: -50, max: -25, label: "-50% to -25%", color: "#a7b2c7" },
   { min: -25, max: 25, label: "-25% to +25%", color: "#e5e7eb" },
-  { min: 25, max: 75, label: "+25% to +75%", color: "#c99a5c" },
+  { min: 25, max: 50, label: "+25% to +50%", color: "#d6b071" },
+  { min: 50, max: 75, label: "+50% to +75%", color: "#b9793f" },
   { min: 75, label: "&gt; +75%", color: "#87552c" },
 ];
 
@@ -156,6 +156,12 @@ function normalizeZip(value) {
   return String(value ?? "").trim().slice(0, 5);
 }
 
+function getFeatureZip(properties) {
+  return normalizeZip(
+    properties.zip_code ?? properties.ZIP_CODE ?? properties.zip ?? properties.Zip,
+  );
+}
+
 function getTilePropertyValue(properties, modeName = activeMode) {
   if (modeName === "gap") {
     const official = Number(properties.tax_year_assessed_value);
@@ -175,39 +181,66 @@ function getTilePropertyValue(properties, modeName = activeMode) {
   return Number(properties[modes[modeName].field]);
 }
 
-function getBreakpoints(modeName = activeMode) {
-  const mode = modes[modeName];
-  const fieldMetadata = metadata?.fields?.[mode.metadataField];
-  const breakpoints =
-    fieldMetadata?.quantile_breakpoints || fieldMetadata?.fixed_breakpoints || [];
+function computeWeightedQuantileBreaksFromBins(bins, classCount = 7) {
+  const rows = normalizeBinRows(bins).filter((row) => row.propertyCount > 0);
+  const total = rows.reduce((sum, row) => sum + row.propertyCount, 0);
 
-  return breakpoints
-    .map((value) => Number(value))
-    .filter((value) => Number.isFinite(value))
-    .sort((left, right) => left - right);
-}
-
-function getValueClassBreaks(modeName = activeMode) {
-  const breakpoints = getBreakpoints(modeName);
-
-  if (breakpoints.length >= VALUE_COLORS.length + 1) {
-    return breakpoints.slice(0, VALUE_COLORS.length + 1);
-  }
-
-  if (breakpoints.length >= 2) {
-    const min = breakpoints[0];
-    const max = breakpoints[breakpoints.length - 1];
-    const step = (max - min) / VALUE_COLORS.length;
-
+  if (rows.length === 0 || total === 0) {
     return Array.from(
-      { length: VALUE_COLORS.length + 1 },
-      (_item, index) => min + step * index,
+      { length: classCount + 1 },
+      (_item, index) => index * 250000,
     );
   }
 
-  return Array.from(
-    { length: VALUE_COLORS.length + 1 },
-    (_item, index) => index * 250000,
+  const breaks = [];
+
+  for (let index = 0; index <= classCount; index += 1) {
+    const target = (total * index) / classCount;
+    let cumulative = 0;
+    let threshold = rows[rows.length - 1].lowerBound;
+
+    for (const row of rows) {
+      const previous = cumulative;
+      cumulative += row.propertyCount;
+
+      if (cumulative >= target) {
+        const upperBound =
+          row.upperBound === null
+            ? row.lowerBound + MAIN_DISPLAY_BIN_SIZE
+            : row.upperBound;
+        const binShare =
+          row.propertyCount === 0 ? 0 : (target - previous) / row.propertyCount;
+        threshold = row.lowerBound + (upperBound - row.lowerBound) * binShare;
+        break;
+      }
+    }
+
+    breaks.push(Math.round(threshold));
+  }
+
+  return breaks.map((value, index) => {
+    if (index === 0) {
+      return value;
+    }
+
+    return Math.max(value, breaks[index - 1] + 1);
+  });
+}
+
+function getChoroplethBins(modeName = activeMode) {
+  const area = getAreaData();
+  const rows =
+    modeName === "estimate" ? area.modelRows : area.officialRows;
+  const fallbackRows =
+    modeName === "estimate" ? citywideModelRows : citywideOfficialRows;
+
+  return rows.length > 0 ? rows : fallbackRows;
+}
+
+function getValueClassBreaks(modeName = activeMode) {
+  return computeWeightedQuantileBreaksFromBins(
+    getChoroplethBins(modeName),
+    VALUE_COLORS.length,
   );
 }
 
@@ -256,9 +289,10 @@ function getColor(value, modeName = activeMode) {
 
 function styleFeature(properties) {
   const value = getTilePropertyValue(properties);
+  const featureZip = getFeatureZip(properties);
   const outsideSelectedZip =
     activeGeography !== "citywide" &&
-    normalizeZip(properties.zip_code) !== normalizeZip(activeGeography);
+    featureZip !== normalizeZip(activeGeography);
   const gapUnavailable = activeMode === "gap" && !Number.isFinite(Number(value));
 
   return {
@@ -352,6 +386,7 @@ function renderTileLayer() {
   propertyTileLayer.on("mouseover", (event) => {
     const properties = event.layer.properties;
     const value = getTilePropertyValue(properties);
+    const featureZip = getFeatureZip(properties);
     const gapLine =
       activeMode === "gap"
         ? `<br>Gap: ${Number.isFinite(Number(value)) ? formatGapPercent(value) : "unavailable"}`
@@ -365,7 +400,7 @@ function renderTileLayer() {
       .setLatLng(event.latlng)
       .setContent(`
         <strong>${properties.address || "Address not available"}</strong><br>
-        ZIP: ${properties.zip_code || "N/A"}<br>
+        ZIP: ${featureZip || "N/A"}<br>
         Official: ${formatMoney(properties.tax_year_assessed_value)}<br>
         Estimate: ${formatMoney(properties.current_assessed_value)}${gapLine}
       `)
@@ -384,7 +419,7 @@ function renderTileLayer() {
 
     if (
       activeGeography !== "citywide" &&
-      normalizeZip(properties.zip_code) !== normalizeZip(activeGeography)
+      getFeatureZip(properties) !== normalizeZip(activeGeography)
     ) {
       setStatus(`That property is outside ZIP ${activeGeography}.`);
       return;
@@ -914,7 +949,7 @@ document.addEventListener("DOMContentLoaded", () => {
     if (
       selectedProperties &&
       activeGeography !== "citywide" &&
-      normalizeZip(selectedProperties.zip_code) !== normalizeZip(activeGeography)
+      getFeatureZip(selectedProperties) !== normalizeZip(activeGeography)
     ) {
       clearSelection();
     }

--- a/ui/reviewer/main.js
+++ b/ui/reviewer/main.js
@@ -1,355 +1,525 @@
-const predictedValueBins = [
-  { lowerBound: 0, upperBound: 10000, propertyCount: 1339 },
-  { lowerBound: 10000, upperBound: 20000, propertyCount: 35665 },
-  { lowerBound: 20000, upperBound: 30000, propertyCount: 38318 },
-  { lowerBound: 30000, upperBound: 40000, propertyCount: 32196 },
-  { lowerBound: 40000, upperBound: 50000, propertyCount: 31308 },
-  { lowerBound: 50000, upperBound: 60000, propertyCount: 31036 },
-  { lowerBound: 60000, upperBound: 70000, propertyCount: 28720 },
-  { lowerBound: 70000, upperBound: 80000, propertyCount: 26311 },
-  { lowerBound: 80000, upperBound: 90000, propertyCount: 24727 },
-  { lowerBound: 90000, upperBound: 100000, propertyCount: 20356 },
-  { lowerBound: 100000, upperBound: 110000, propertyCount: 23083 },
-  { lowerBound: 110000, upperBound: 120000, propertyCount: 20659 },
-  { lowerBound: 120000, upperBound: 130000, propertyCount: 14872 },
-  { lowerBound: 130000, upperBound: 140000, propertyCount: 11732 },
-  { lowerBound: 140000, upperBound: 150000, propertyCount: 18632 },
-  { lowerBound: 150000, upperBound: 160000, propertyCount: 11185 },
-  { lowerBound: 160000, upperBound: 170000, propertyCount: 15253 },
-  { lowerBound: 170000, upperBound: 180000, propertyCount: 7702 },
-  { lowerBound: 180000, upperBound: 190000, propertyCount: 7315 },
-  { lowerBound: 190000, upperBound: 200000, propertyCount: 9517 },
-  { lowerBound: 200000, upperBound: 210000, propertyCount: 6613 },
-  { lowerBound: 210000, upperBound: 220000, propertyCount: 7910 },
-  { lowerBound: 220000, upperBound: 230000, propertyCount: 4909 },
-  { lowerBound: 230000, upperBound: 240000, propertyCount: 5516 },
-  { lowerBound: 240000, upperBound: 250000, propertyCount: 4203 },
-  { lowerBound: 250000, upperBound: 260000, propertyCount: 3942 },
-  { lowerBound: 260000, upperBound: 270000, propertyCount: 3463 },
-  { lowerBound: 270000, upperBound: 280000, propertyCount: 3456 },
-  { lowerBound: 280000, upperBound: 290000, propertyCount: 3090 },
-  { lowerBound: 290000, upperBound: 300000, propertyCount: 2884 },
-  { lowerBound: 300000, upperBound: 310000, propertyCount: 2834 },
-  { lowerBound: 310000, upperBound: 320000, propertyCount: 2842 },
-  { lowerBound: 320000, upperBound: 330000, propertyCount: 2070 },
-  { lowerBound: 330000, upperBound: 340000, propertyCount: 2653 },
-  { lowerBound: 340000, upperBound: 350000, propertyCount: 2395 },
-  { lowerBound: 350000, upperBound: 360000, propertyCount: 2391 },
-  { lowerBound: 360000, upperBound: 370000, propertyCount: 2017 },
-  { lowerBound: 370000, upperBound: 380000, propertyCount: 2373 },
-  { lowerBound: 380000, upperBound: 390000, propertyCount: 1686 },
-  { lowerBound: 390000, upperBound: 400000, propertyCount: 1951 },
-  { lowerBound: 400000, upperBound: 410000, propertyCount: 1187 },
-  { lowerBound: 410000, upperBound: 420000, propertyCount: 1715 },
-  { lowerBound: 420000, upperBound: 430000, propertyCount: 1376 },
-  { lowerBound: 430000, upperBound: 440000, propertyCount: 1191 },
-  { lowerBound: 440000, upperBound: 450000, propertyCount: 985 },
-  { lowerBound: 450000, upperBound: 460000, propertyCount: 794 },
-  { lowerBound: 460000, upperBound: 470000, propertyCount: 1444 },
-  { lowerBound: 470000, upperBound: 480000, propertyCount: 663 },
-  { lowerBound: 480000, upperBound: 490000, propertyCount: 920 },
-  { lowerBound: 490000, upperBound: 500000, propertyCount: 718 },
-  { lowerBound: 500000, upperBound: 510000, propertyCount: 982 },
-  { lowerBound: 510000, upperBound: 520000, propertyCount: 906 },
-  { lowerBound: 520000, upperBound: 530000, propertyCount: 921 },
-  { lowerBound: 530000, upperBound: 540000, propertyCount: 628 },
-  { lowerBound: 540000, upperBound: 550000, propertyCount: 977 },
-  { lowerBound: 550000, upperBound: 560000, propertyCount: 433 },
-  { lowerBound: 560000, upperBound: 570000, propertyCount: 262 },
-  { lowerBound: 570000, upperBound: 580000, propertyCount: 408 },
-  { lowerBound: 580000, upperBound: 590000, propertyCount: 310 },
-  { lowerBound: 590000, upperBound: 600000, propertyCount: 628 },
-  { lowerBound: 600000, upperBound: 610000, propertyCount: 374 },
-  { lowerBound: 610000, upperBound: 620000, propertyCount: 183 },
-  { lowerBound: 620000, upperBound: 630000, propertyCount: 158 },
-  { lowerBound: 630000, upperBound: 640000, propertyCount: 463 },
-  { lowerBound: 640000, upperBound: 650000, propertyCount: 190 },
-  { lowerBound: 650000, upperBound: 660000, propertyCount: 310 },
-  { lowerBound: 660000, upperBound: 670000, propertyCount: 112 },
-  { lowerBound: 670000, upperBound: 680000, propertyCount: 157 },
-  { lowerBound: 680000, upperBound: 690000, propertyCount: 311 },
-  { lowerBound: 690000, upperBound: 700000, propertyCount: 174 },
-  { lowerBound: 700000, upperBound: 710000, propertyCount: 167 },
-  { lowerBound: 710000, upperBound: 720000, propertyCount: 197 },
-  { lowerBound: 720000, upperBound: 730000, propertyCount: 117 },
-  { lowerBound: 730000, upperBound: 740000, propertyCount: 184 },
-  { lowerBound: 740000, upperBound: 750000, propertyCount: 217 },
-  { lowerBound: 750000, upperBound: 760000, propertyCount: 88 },
-  { lowerBound: 760000, upperBound: 770000, propertyCount: 236 },
-  { lowerBound: 770000, upperBound: 780000, propertyCount: 221 },
-  { lowerBound: 780000, upperBound: 790000, propertyCount: 110 },
-  { lowerBound: 790000, upperBound: 800000, propertyCount: 272 },
-  { lowerBound: 800000, upperBound: 810000, propertyCount: 218 },
-  { lowerBound: 810000, upperBound: 820000, propertyCount: 186 },
-  { lowerBound: 820000, upperBound: 830000, propertyCount: 445 },
-  { lowerBound: 830000, upperBound: 840000, propertyCount: 223 },
-  { lowerBound: 840000, upperBound: 850000, propertyCount: 174 },
-  { lowerBound: 850000, upperBound: 860000, propertyCount: 266 },
-  { lowerBound: 860000, upperBound: 870000, propertyCount: 159 },
-  { lowerBound: 870000, upperBound: 880000, propertyCount: 141 },
-  { lowerBound: 880000, upperBound: 890000, propertyCount: 95 },
-  { lowerBound: 890000, upperBound: 900000, propertyCount: 150 },
-  { lowerBound: 900000, upperBound: 910000, propertyCount: 337 },
-  { lowerBound: 910000, upperBound: 920000, propertyCount: 157 },
-  { lowerBound: 920000, upperBound: 930000, propertyCount: 92 },
-  { lowerBound: 930000, upperBound: 940000, propertyCount: 155 },
-  { lowerBound: 940000, upperBound: 950000, propertyCount: 52 },
-  { lowerBound: 950000, upperBound: 960000, propertyCount: 133 },
-  { lowerBound: 960000, upperBound: 970000, propertyCount: 187 },
-  { lowerBound: 970000, upperBound: 980000, propertyCount: 102 },
-  { lowerBound: 980000, upperBound: 990000, propertyCount: 151 },
-  { lowerBound: 990000, upperBound: 1000000, propertyCount: 160 },
-  { lowerBound: 1000000, upperBound: 1010000, propertyCount: 89 },
-  { lowerBound: 1010000, upperBound: 1020000, propertyCount: 82 },
-  { lowerBound: 1020000, upperBound: 1030000, propertyCount: 166 },
-  { lowerBound: 1030000, upperBound: 1040000, propertyCount: 114 },
-  { lowerBound: 1040000, upperBound: 1050000, propertyCount: 246 },
-  { lowerBound: 1050000, upperBound: 1060000, propertyCount: 74 },
-  { lowerBound: 1060000, upperBound: 1070000, propertyCount: 85 },
-  { lowerBound: 1070000, upperBound: 1080000, propertyCount: 129 },
-  { lowerBound: 1080000, upperBound: 1090000, propertyCount: 60 },
-  { lowerBound: 1090000, upperBound: 1100000, propertyCount: 107 },
-  { lowerBound: 1100000, upperBound: 1110000, propertyCount: 43 },
-  { lowerBound: 1110000, upperBound: 1120000, propertyCount: 18 },
-  { lowerBound: 1120000, upperBound: 1130000, propertyCount: 47 },
-  { lowerBound: 1130000, upperBound: 1140000, propertyCount: 376 },
-  { lowerBound: 1140000, upperBound: 1150000, propertyCount: 86 },
-  { lowerBound: 1150000, upperBound: 1160000, propertyCount: 43 },
-  { lowerBound: 1160000, upperBound: 1170000, propertyCount: 29 },
-  { lowerBound: 1170000, upperBound: 1180000, propertyCount: 72 },
-  { lowerBound: 1180000, upperBound: 1190000, propertyCount: 32 },
-  { lowerBound: 1190000, upperBound: 1200000, propertyCount: 66 },
-  { lowerBound: 1200000, upperBound: 1210000, propertyCount: 20 },
-  { lowerBound: 1210000, upperBound: 1220000, propertyCount: 53 },
-  { lowerBound: 1220000, upperBound: 1230000, propertyCount: 36 },
-  { lowerBound: 1230000, upperBound: 1240000, propertyCount: 25 },
-  { lowerBound: 1240000, upperBound: 1250000, propertyCount: 64 },
-  { lowerBound: 1250000, upperBound: 1260000, propertyCount: 12 },
-  { lowerBound: 1260000, upperBound: 1270000, propertyCount: 2 },
-  { lowerBound: 1270000, upperBound: 1280000, propertyCount: 24 },
-  { lowerBound: 1280000, upperBound: 1290000, propertyCount: 32 },
-  { lowerBound: 1290000, upperBound: 1300000, propertyCount: 37 },
-  { lowerBound: 1300000, upperBound: 1310000, propertyCount: 60 },
-  { lowerBound: 1320000, upperBound: 1330000, propertyCount: 28 },
-  { lowerBound: 1330000, upperBound: 1340000, propertyCount: 41 },
-  { lowerBound: 1340000, upperBound: 1350000, propertyCount: 28 },
-  { lowerBound: 1350000, upperBound: 1360000, propertyCount: 5 },
-  { lowerBound: 1360000, upperBound: 1370000, propertyCount: 6 },
-  { lowerBound: 1370000, upperBound: 1380000, propertyCount: 2 },
-  { lowerBound: 1380000, upperBound: 1390000, propertyCount: 4 },
-  { lowerBound: 1390000, upperBound: 1400000, propertyCount: 3 },
-  { lowerBound: 1400000, upperBound: 1410000, propertyCount: 25 },
-  { lowerBound: 1410000, upperBound: 1420000, propertyCount: 4 },
-  { lowerBound: 1420000, upperBound: 1430000, propertyCount: 18 },
-  { lowerBound: 1430000, upperBound: 1440000, propertyCount: 6 },
-  { lowerBound: 1440000, upperBound: 1450000, propertyCount: 104 },
-  { lowerBound: 1450000, upperBound: 1460000, propertyCount: 34 },
-  { lowerBound: 1460000, upperBound: 1470000, propertyCount: 24 },
-  { lowerBound: 1480000, upperBound: 1490000, propertyCount: 3 },
-  { lowerBound: 1490000, upperBound: 1500000, propertyCount: 16 },
-  { lowerBound: 1510000, upperBound: 1520000, propertyCount: 12 },
-  { lowerBound: 1540000, upperBound: 1550000, propertyCount: 1 },
-  { lowerBound: 1550000, upperBound: 1560000, propertyCount: 13 },
-  { lowerBound: 1580000, upperBound: 1590000, propertyCount: 11 },
-  { lowerBound: 1610000, upperBound: 1620000, propertyCount: 3 },
-  { lowerBound: 1620000, upperBound: 1630000, propertyCount: 18 },
-  { lowerBound: 1640000, upperBound: 1650000, propertyCount: 7 },
-  { lowerBound: 1660000, upperBound: 1670000, propertyCount: 22 },
-  { lowerBound: 1680000, upperBound: 1690000, propertyCount: 7 },
-  { lowerBound: 1720000, upperBound: 1730000, propertyCount: 1 },
-  { lowerBound: 1730000, upperBound: 1740000, propertyCount: 20 },
-  { lowerBound: 1790000, upperBound: 1800000, propertyCount: 5 },
-];
+const PUBLIC_BASE_URL =
+  "https://storage.googleapis.com/musa5090s26-team1-public";
+const MAP_STYLE_METADATA_URL = `${PUBLIC_BASE_URL}/configs/map_style_metadata.json`;
+const TAX_YEAR_ASSESSMENT_BINS_URL = `${PUBLIC_BASE_URL}/configs/tax_year_assessment_bins.json`;
+const CURRENT_ASSESSMENT_BINS_URL = `${PUBLIC_BASE_URL}/configs/current_assessment_bins.json`;
 
-const map = L.map("map").setView([40.04, -75.28], 12);
+const DEFAULT_TILE_URL = `${PUBLIC_BASE_URL}/tiles/properties/{z}/{x}/{y}.pbf`;
+const DEFAULT_TILE_LAYER = "property_tile_info";
+const MAIN_DISPLAY_MAX = 2500000;
+const MAIN_DISPLAY_BIN_SIZE = 100000;
+const VALUE_COLORS = ["#eff6ff", "#bfdbfe", "#93c5fd", "#60a5fa", "#2563eb", "#1e3a8a"];
+const GAP_COLORS = ["#53627f", "#8798b3", "#d8dee9", "#e2c48f", "#c98c4a", "#87552c"];
+
+const map = L.map("map", {
+  zoomControl: true,
+}).setView([39.9526, -75.1652], 12);
 
 L.tileLayer("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png", {
   attribution: "&copy; OpenStreetMap contributors",
 }).addTo(map);
 
-const propertyTileUrl =
-  "https://storage.googleapis.com/musa5090s26-team1-public/tiles/properties/{z}/{x}/{y}.pbf";
+let metadata = null;
+let activeMode = "official";
+let propertyTileLayer = null;
+let hoverPopup = null;
+let officialChart = null;
+let modelChart = null;
+let legendControl = null;
 
-const propertyTileLayerName = "property_tile_info";
+const modes = {
+  official: {
+    label: "Official Value",
+    description: "Showing official assessed value across residential parcels.",
+    field: "tax_year_assessed_value",
+    metadataField: "tax_year_assessed_value",
+    colors: VALUE_COLORS,
+  },
+  estimate: {
+    label: "Model Estimate",
+    description: "Showing model estimated current market value across residential parcels.",
+    field: "current_assessed_value",
+    metadataField: "current_assessed_value",
+    colors: VALUE_COLORS,
+  },
+  gap: {
+    label: "Gap (%)",
+    description: "Showing percent difference between model estimate and official value.",
+    field: "gap_pct",
+    metadataField: "percent_change",
+    colors: GAP_COLORS,
+  },
+};
 
-function getAssessmentColor(value) {
-  const numericValue = Number(value);
+function formatMoney(value) {
+  const number = Number(value);
 
-  if (!Number.isFinite(numericValue)) {
-    return "#d1d5db";
+  if (!Number.isFinite(number)) {
+    return "N/A";
   }
 
-  if (numericValue < 100000) {
-    return "#fee5d9";
-  }
-
-  if (numericValue < 250000) {
-    return "#fcae91";
-  }
-
-  if (numericValue < 500000) {
-    return "#fb6a4a";
-  }
-
-  if (numericValue < 750000) {
-    return "#de2d26";
-  }
-
-  if (numericValue < 1000000) {
-    return "#a50f15";
-  }
-
-  return "#67000d";
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    maximumFractionDigits: 0,
+  }).format(number);
 }
 
-console.log("VectorGrid available?", L.vectorGrid);
+function formatCompactMoney(value) {
+  const number = Number(value);
 
-const propertyTileLayer = L.vectorGrid.protobuf(propertyTileUrl, {
-  rendererFactory: L.canvas.tile,
-  interactive: true,
-  minZoom: 12,
-  maxZoom: 18,
-  maxNativeZoom: 18,
-  vectorTileLayerStyles: {
-    [propertyTileLayerName]: (properties) => {
-      console.log("property tile props", properties);
+  if (!Number.isFinite(number)) {
+    return "N/A";
+  }
 
-      return {
-        fill: true,
-        fillColor: getAssessmentColor(properties.current_assessed_value),
-        fillOpacity: 0.65,
-        color: "#ffffff",
-        opacity: 0.4,
-        weight: 0.5,
-      };
-    },
-  },
-});
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    notation: "compact",
+    maximumFractionDigits: 1,
+  }).format(number);
+}
 
-propertyTileLayer.on("click", (event) => {
-  const props = event.layer.properties;
+function formatNumber(value) {
+  const number = Number(value);
 
-  L.popup()
-    .setLatLng(event.latlng)
-    .setContent(`
-      <strong>${props.address || "Unknown address"}</strong><br>
-      Property ID: ${props.property_id || "N/A"}<br>
-      Current assessed value: ${
-        props.current_assessed_value
-          ? `$${Number(props.current_assessed_value).toLocaleString()}`
-          : "N/A"
-      }<br>
-      Tax year assessed value: ${
-        props.tax_year_assessed_value
-          ? `$${Number(props.tax_year_assessed_value).toLocaleString()}`
-          : "N/A"
-      }
-    `)
-    .openOn(map);
-});
+  if (!Number.isFinite(number)) {
+    return "N/A";
+  }
 
-propertyTileLayer.addTo(map);
+  return new Intl.NumberFormat("en-US").format(Math.round(number));
+}
 
-const neighborhoodPoints = [
-  {
-    name: "Center City",
-    lat: 39.9526,
-    lng: -75.1652,
-    valueBand: "$100k–$110k",
-  },
-  {
-    name: "University City",
-    lat: 39.9607,
-    lng: -75.1993,
-    valueBand: "$90k–$100k",
-  },
-  {
-    name: "West Philadelphia",
-    lat: 39.9651,
-    lng: -75.2217,
-    valueBand: "$70k–$80k",
-  },
-  {
-    name: "Fishtown",
-    lat: 39.9697,
-    lng: -75.1339,
-    valueBand: "$120k–$130k",
-  },
-];
+function formatPercent(value) {
+  const number = Number(value);
 
-neighborhoodPoints.forEach((point) => {
-  L.circleMarker([point.lat, point.lng], {
-    radius: 9,
-    weight: 2,
+  if (!Number.isFinite(number)) {
+    return "N/A";
+  }
+
+  return new Intl.NumberFormat("en-US", {
+    style: "percent",
+    maximumFractionDigits: 1,
+  }).format(number);
+}
+
+function setStatus(message = "") {
+  document.getElementById("mapStatus").textContent = message;
+}
+
+function getTilePropertyValue(properties, modeName = activeMode) {
+  if (modeName === "gap") {
+    const official = Number(properties.tax_year_assessed_value);
+    const estimate = Number(properties.current_assessed_value);
+
+    if (!Number.isFinite(official) || official === 0 || !Number.isFinite(estimate)) {
+      return null;
+    }
+
+    return (estimate - official) / official;
+  }
+
+  return Number(properties[modes[modeName].field]);
+}
+
+function getBreakpoints(modeName = activeMode) {
+  const mode = modes[modeName];
+  const fieldMetadata = metadata?.fields?.[mode.metadataField];
+  const breakpoints =
+    fieldMetadata?.quantile_breakpoints || fieldMetadata?.fixed_breakpoints || [];
+
+  return breakpoints
+    .map((value) => Number(value))
+    .filter((value) => Number.isFinite(value))
+    .sort((left, right) => left - right);
+}
+
+function getColor(value, modeName = activeMode) {
+  const number = Number(value);
+  const mode = modes[modeName];
+  const breakpoints = getBreakpoints(modeName);
+
+  if (!Number.isFinite(number)) {
+    return "#cfd6df";
+  }
+
+  if (breakpoints.length < 2) {
+    return mode.colors[Math.floor(mode.colors.length / 2)];
+  }
+
+  let index = 0;
+  for (let i = 1; i < breakpoints.length; i += 1) {
+    if (number >= breakpoints[i]) {
+      index = i;
+    }
+  }
+
+  return mode.colors[Math.min(index, mode.colors.length - 1)];
+}
+
+function styleFeature(properties) {
+  return {
+    fill: true,
+    fillColor: getColor(getTilePropertyValue(properties)),
+    fillOpacity: 0.72,
     color: "#ffffff",
-    fillColor: "#688898",
-    fillOpacity: 0.9,
-  })
-    .addTo(map)
-    .bindPopup(
-      `<strong>${point.name}</strong><br/>Predicted value band: ${point.valueBand}`,
-    );
-});
-
-function formatBinLabel(lower, upper) {
-  return `$${Math.round(lower / 1000)}k–$${Math.round(upper / 1000)}k`;
+    opacity: 0.35,
+    weight: 0.45,
+  };
 }
 
-function formatYAxisValue(value) {
-  return Math.round(value).toLocaleString();
+function formatModeValue(value, modeName = activeMode) {
+  return modeName === "gap" ? formatPercent(value) : formatMoney(value);
 }
 
-function renderDistributionHistogram(data) {
-  const container = document.getElementById("distributionChart");
-  const yAxis = document.getElementById("distributionYAxis");
+function getTileConfig() {
+  return {
+    url: metadata?.vector_tiles?.url_template || DEFAULT_TILE_URL,
+    sourceLayer: metadata?.vector_tiles?.source_layer || DEFAULT_TILE_LAYER,
+    minzoom: Number(metadata?.vector_tiles?.minzoom) || 12,
+    maxzoom: Number(metadata?.vector_tiles?.maxzoom) || 18,
+  };
+}
 
-  if (!container || !yAxis) {
+function renderLegend() {
+  const mode = modes[activeMode];
+  const breakpoints = getBreakpoints();
+
+  if (!legendControl) {
+    legendControl = L.control({ position: "bottomright" });
+    legendControl.onAdd = () => {
+      const div = L.DomUtil.create("div", "map-legend");
+      div.id = "mapLegend";
+      return div;
+    };
+    legendControl.addTo(map);
+  }
+
+  const legend = document.getElementById("mapLegend");
+  const labels = breakpoints.slice(0, mode.colors.length).map((breakpoint, index) => {
+    const next = breakpoints[index + 1];
+    const label =
+      next === undefined
+        ? `${formatModeValue(breakpoint)}+`
+        : `${formatModeValue(breakpoint)} to ${formatModeValue(next)}`;
+
+    return `
+      <div class="legend-row">
+        <span style="background:${mode.colors[index]}"></span>
+        <em>${label}</em>
+      </div>
+    `;
+  });
+
+  legend.innerHTML = `
+    <strong>${mode.label}</strong>
+    ${labels.join("")}
+  `;
+}
+
+function renderTileLayer() {
+  const tileConfig = getTileConfig();
+
+  if (propertyTileLayer) {
+    map.removeLayer(propertyTileLayer);
+  }
+
+  propertyTileLayer = L.vectorGrid.protobuf(tileConfig.url, {
+    rendererFactory: L.canvas.tile,
+    interactive: true,
+    minZoom: tileConfig.minzoom,
+    maxZoom: tileConfig.maxzoom,
+    maxNativeZoom: tileConfig.maxzoom,
+    vectorTileLayerStyles: {
+      [tileConfig.sourceLayer]: styleFeature,
+    },
+  });
+
+  propertyTileLayer.on("mouseover", (event) => {
+    const properties = event.layer.properties;
+    const value = getTilePropertyValue(properties);
+
+    hoverPopup = L.popup({
+      closeButton: false,
+      autoPan: false,
+      className: "hover-popup",
+    })
+      .setLatLng(event.latlng)
+      .setContent(`
+        <strong>${properties.address || "Address not available"}</strong><br>
+        Official: ${formatMoney(properties.tax_year_assessed_value)}<br>
+        Estimate: ${formatMoney(properties.current_assessed_value)}<br>
+        ${modes[activeMode].label}: ${formatModeValue(value)}
+      `)
+      .openOn(map);
+  });
+
+  propertyTileLayer.on("mouseout", () => {
+    if (hoverPopup) {
+      map.closePopup(hoverPopup);
+      hoverPopup = null;
+    }
+  });
+
+  propertyTileLayer.on("click", (event) => {
+    renderSelectedProperty(event.layer.properties);
+  });
+
+  propertyTileLayer.addTo(map);
+  renderLegend();
+}
+
+function renderModeControls() {
+  document.querySelectorAll(".mode-button").forEach((button) => {
+    button.classList.toggle("active", button.dataset.mode === activeMode);
+  });
+  document.getElementById("modeLabel").textContent = modes[activeMode].description;
+  renderLegend();
+
+  if (propertyTileLayer) {
+    renderTileLayer();
+  }
+}
+
+function calculateGapValue(properties) {
+  const official = Number(properties.tax_year_assessed_value);
+  const estimate = Number(properties.current_assessed_value);
+
+  if (!Number.isFinite(official) || !Number.isFinite(estimate)) {
+    return null;
+  }
+
+  return estimate - official;
+}
+
+function calculateGapPercent(properties) {
+  const official = Number(properties.tax_year_assessed_value);
+  const gap = calculateGapValue(properties);
+
+  if (!Number.isFinite(official) || official === 0 || !Number.isFinite(gap)) {
+    return null;
+  }
+
+  return gap / official;
+}
+
+function renderSelectedProperty(properties) {
+  document.getElementById("citywidePanel").hidden = true;
+  document.getElementById("selectedPanel").hidden = false;
+  document.getElementById("selectedAddress").textContent =
+    properties.address || "Address not available";
+  document.getElementById("selectedPropertyId").textContent =
+    properties.property_id || "N/A";
+  document.getElementById("selectedOfficialValue").textContent = formatMoney(
+    properties.tax_year_assessed_value,
+  );
+  document.getElementById("selectedEstimateValue").textContent = formatMoney(
+    properties.current_assessed_value,
+  );
+  document.getElementById("selectedGapValue").textContent =
+    `${formatMoney(calculateGapValue(properties))} (${formatPercent(calculateGapPercent(properties))})`;
+}
+
+function clearSelection() {
+  document.getElementById("citywidePanel").hidden = false;
+  document.getElementById("selectedPanel").hidden = true;
+}
+
+function normalizeBinRows(rows) {
+  return rows
+    .map((row) => ({
+      lowerBound: Number(row.lower_bound),
+      upperBound: Number(row.upper_bound),
+      propertyCount: Number(row.property_count),
+    }))
+    .filter(
+      (row) =>
+        Number.isFinite(row.lowerBound) &&
+        Number.isFinite(row.upperBound) &&
+        Number.isFinite(row.propertyCount),
+    )
+    .sort((left, right) => left.lowerBound - right.lowerBound);
+}
+
+function buildDisplayBins(rows) {
+  const bins = [];
+
+  for (let lowerBound = 0; lowerBound < MAIN_DISPLAY_MAX; lowerBound += MAIN_DISPLAY_BIN_SIZE) {
+    bins.push({
+      lowerBound,
+      upperBound: lowerBound + MAIN_DISPLAY_BIN_SIZE,
+      propertyCount: 0,
+      label: lowerBound === 0 || lowerBound % 500000 === 0 ? formatCompactMoney(lowerBound) : "",
+    });
+  }
+
+  bins.push({
+    lowerBound: MAIN_DISPLAY_MAX,
+    upperBound: null,
+    propertyCount: 0,
+    label: ">$2.5M",
+  });
+
+  rows.forEach((row) => {
+    if (row.lowerBound >= MAIN_DISPLAY_MAX || row.upperBound > MAIN_DISPLAY_MAX) {
+      bins[bins.length - 1].propertyCount += row.propertyCount;
+      return;
+    }
+
+    const index = Math.floor(row.lowerBound / MAIN_DISPLAY_BIN_SIZE);
+    if (bins[index]) {
+      bins[index].propertyCount += row.propertyCount;
+    }
+  });
+
+  return bins;
+}
+
+function renderDistributionChart(chartElementId, rows, chartRef) {
+  const chartElement = document.getElementById(chartElementId);
+
+  if (chartRef) {
+    chartRef.destroy();
+  }
+
+  const chart = new window.ApexCharts(chartElement, {
+    chart: {
+      type: "bar",
+      height: 220,
+      toolbar: {
+        show: false,
+      },
+    },
+    series: [
+      {
+        name: "Properties",
+        data: rows.map((row) => row.propertyCount),
+      },
+    ],
+    colors: ["#1f5f99"],
+    dataLabels: {
+      enabled: false,
+    },
+    plotOptions: {
+      bar: {
+        columnWidth: "85%",
+      },
+    },
+    grid: {
+      borderColor: "#d9dde5",
+      strokeDashArray: 3,
+    },
+    xaxis: {
+      categories: rows.map((row) => row.label),
+      labels: {
+        rotate: 0,
+        hideOverlappingLabels: true,
+      },
+    },
+    yaxis: {
+      labels: {
+        formatter: (value) => formatNumber(value),
+      },
+    },
+    tooltip: {
+      y: {
+        formatter: (value) => `${formatNumber(value)} properties`,
+      },
+    },
+  });
+
+  chart.render();
+  return chart;
+}
+
+async function loadDistributionCharts() {
+  if (!window.ApexCharts) {
+    document.getElementById("officialChartHelper").textContent =
+      "Chart library failed to load.";
+    document.getElementById("modelChartHelper").textContent =
+      "Chart library failed to load.";
     return;
   }
 
-  container.innerHTML = "";
-  yAxis.innerHTML = "";
+  const [officialResponse, modelResponse] = await Promise.all([
+    fetch(TAX_YEAR_ASSESSMENT_BINS_URL),
+    fetch(CURRENT_ASSESSMENT_BINS_URL),
+  ]);
 
-  const maxCount = Math.max(...data.map((d) => d.propertyCount));
-  const tickCount = 5;
-
-  for (let i = tickCount; i >= 0; i -= 1) {
-    const tick = document.createElement("div");
-    tick.textContent = formatYAxisValue((maxCount / tickCount) * i);
-    yAxis.appendChild(tick);
+  if (!officialResponse.ok || !modelResponse.ok) {
+    throw new Error("Unable to load one or more public distribution configs.");
   }
 
-  const chart = document.createElement("div");
-  chart.className = "histogram-bars";
+  const [officialPayload, modelPayload] = await Promise.all([
+    officialResponse.json(),
+    modelResponse.json(),
+  ]);
 
-  data.forEach((bin, index) => {
-    const group = document.createElement("div");
-    group.className = "histogram-group";
+  const taxYears = officialPayload
+    .map((row) => Number(row.tax_year))
+    .filter((taxYear) => Number.isFinite(taxYear));
+  const latestTaxYear = Math.max(...taxYears);
+  const latestOfficialRows = officialPayload.filter(
+    (row) => Number(row.tax_year) === latestTaxYear,
+  );
 
-    const bar = document.createElement("div");
-    bar.className = "histogram-bar";
-    bar.style.height = `${(bin.propertyCount / maxCount) * 100}%`;
-    bar.title = `${formatBinLabel(
-      bin.lowerBound,
-      bin.upperBound,
-    )}: ${bin.propertyCount.toLocaleString()} properties`;
+  officialChart = renderDistributionChart(
+    "officialDistributionChart",
+    buildDisplayBins(normalizeBinRows(latestOfficialRows)),
+    officialChart,
+  );
+  modelChart = renderDistributionChart(
+    "modelDistributionChart",
+    buildDisplayBins(normalizeBinRows(modelPayload)),
+    modelChart,
+  );
 
-    const label = document.createElement("span");
-    label.className = "histogram-label";
-
-    const shouldShow =
-      index === 0 || index === data.length - 1 || index % 2 === 0;
-
-    label.textContent = shouldShow
-      ? formatBinLabel(bin.lowerBound, bin.upperBound)
-      : "";
-
-    group.appendChild(bar);
-    group.appendChild(label);
-    chart.appendChild(group);
-  });
-
-  container.appendChild(chart);
+  document.getElementById("officialChartHelper").textContent =
+    `Latest tax year ${latestTaxYear}; values above $2.5M are grouped.`;
+  document.getElementById("modelChartHelper").textContent =
+    "Current model estimates; values above $2.5M are grouped.";
 }
 
-renderDistributionHistogram(predictedValueBins);
+function renderMetadataSummary() {
+  document.getElementById("recordCountText").textContent = formatNumber(
+    metadata?.record_count,
+  );
+  document.getElementById("defaultFieldText").textContent =
+    metadata?.default_style_field || "current_assessed_value";
+}
+
+async function initializeDashboard() {
+  try {
+    const metadataResponse = await fetch(MAP_STYLE_METADATA_URL);
+    if (!metadataResponse.ok) {
+      throw new Error("Unable to load map style metadata.");
+    }
+
+    metadata = await metadataResponse.json();
+    renderMetadataSummary();
+    renderTileLayer();
+    await loadDistributionCharts();
+    setStatus("");
+  } catch (error) {
+    setStatus(
+      error instanceof Error
+        ? error.message
+        : "Unable to load public dashboard assets.",
+    );
+    metadata = metadata || {};
+    renderMetadataSummary();
+    renderTileLayer();
+  }
+}
+
+document.addEventListener("DOMContentLoaded", () => {
+  document.querySelectorAll(".mode-button").forEach((button) => {
+    button.addEventListener("click", () => {
+      activeMode = button.dataset.mode;
+      renderModeControls();
+    });
+  });
+
+  document.getElementById("clearSelectionBtn").addEventListener("click", clearSelection);
+  initializeDashboard();
+});

--- a/ui/reviewer/main.js
+++ b/ui/reviewer/main.js
@@ -13,6 +13,7 @@ const DEFAULT_TILE_URL = `${PUBLIC_BASE_URL}/tiles/properties/{z}/{x}/{y}.pbf`;
 const DEFAULT_TILE_LAYER = "property_tile_info";
 const MAIN_DISPLAY_MAX = 2500000;
 const MAIN_DISPLAY_BIN_SIZE = 100000;
+const ZIP_DETAIL_MIN_ZOOM = 14;
 const VALUE_COLORS = ["#eff6ff", "#bfdbfe", "#93c5fd", "#60a5fa", "#2563eb", "#1e3a8a"];
 const GAP_UNAVAILABLE_COLOR = "#d9dde5";
 const GAP_BINS = [
@@ -142,6 +143,28 @@ function setStatus(message = "") {
   document.getElementById("mapStatus").textContent = message;
 }
 
+function shouldApplyZipDetailTreatment() {
+  return activeGeography !== "citywide" && map.getZoom() >= ZIP_DETAIL_MIN_ZOOM;
+}
+
+function updateZipZoomMessage() {
+  const message = document.getElementById("zipZoomMessage");
+  const shouldShow =
+    activeGeography !== "citywide" && map.getZoom() < ZIP_DETAIL_MIN_ZOOM;
+
+  message.hidden = !shouldShow;
+}
+
+function ensureZipDetailZoom() {
+  if (activeGeography === "citywide" || !map) {
+    return;
+  }
+
+  if (map.getZoom() < ZIP_DETAIL_MIN_ZOOM) {
+    map.setZoom(ZIP_DETAIL_MIN_ZOOM);
+  }
+}
+
 function getTilePropertyValue(properties, modeName = activeMode) {
   if (modeName === "gap") {
     const official = Number(properties.tax_year_assessed_value);
@@ -218,7 +241,7 @@ function getColor(value, modeName = activeMode) {
 function styleFeature(properties) {
   const value = getTilePropertyValue(properties);
   const outsideSelectedZip =
-    activeGeography !== "citywide" && properties.zip_code !== activeGeography;
+    shouldApplyZipDetailTreatment() && properties.zip_code !== activeGeography;
   const gapUnavailable = activeMode === "gap" && !Number.isFinite(Number(value));
 
   return {
@@ -338,7 +361,10 @@ function renderTileLayer() {
   propertyTileLayer.on("click", (event) => {
     const properties = event.layer.properties;
 
-    if (activeGeography !== "citywide" && properties.zip_code !== activeGeography) {
+    if (
+      shouldApplyZipDetailTreatment() &&
+      properties.zip_code !== activeGeography
+    ) {
       setStatus(`That property is outside ZIP ${activeGeography}.`);
       return;
     }
@@ -620,6 +646,24 @@ function renderModeControls() {
   }
 }
 
+function getGapClass(value) {
+  const number = Number(value);
+
+  if (!Number.isFinite(number)) {
+    return "gap-neutral";
+  }
+
+  if (number > 0) {
+    return "gap-positive";
+  }
+
+  if (number < 0) {
+    return "gap-negative";
+  }
+
+  return "gap-neutral";
+}
+
 function calculateGapValue(properties) {
   const official = Number(properties.tax_year_assessed_value);
   const estimate = Number(properties.current_assessed_value);
@@ -757,8 +801,11 @@ function renderSelectedProperty(properties) {
   document.getElementById("selectedEstimateValue").textContent = formatMoney(
     properties.current_assessed_value,
   );
-  document.getElementById("selectedGapValue").textContent =
-    `${formatMoney(calculateGapValue(properties))} (${formatGapPercent(calculateGapPercent(properties))})`;
+  const gapPercent = calculateGapPercent(properties);
+  const selectedGapElement = document.getElementById("selectedGapValue");
+  selectedGapElement.className = getGapClass(gapPercent);
+  selectedGapElement.textContent =
+    `${formatMoney(calculateGapValue(properties))} (${formatGapPercent(gapPercent)})`;
   document.getElementById("selectedHistoryHelper").textContent =
     "Loading assessment history...";
   document.getElementById("selectedHistoryChart").innerHTML = "";
@@ -819,6 +866,7 @@ async function initializeDashboard() {
     updateSummary();
     updateCharts();
     renderTileLayer();
+    updateZipZoomMessage();
     setStatus("");
   } catch (error) {
     setStatus(
@@ -830,6 +878,7 @@ async function initializeDashboard() {
     zipContext = zipContext || { areas: {} };
     updateSummary();
     renderTileLayer();
+    updateZipZoomMessage();
   }
 }
 
@@ -843,6 +892,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
   document.getElementById("geographySelect").addEventListener("change", (event) => {
     activeGeography = event.target.value;
+    ensureZipDetailZoom();
     if (
       selectedProperties &&
       activeGeography !== "citywide" &&
@@ -852,9 +902,16 @@ document.addEventListener("DOMContentLoaded", () => {
     }
     updateSummary();
     updateCharts();
+    updateZipZoomMessage();
     renderTileLayer();
   });
 
   document.getElementById("clearSelectionBtn").addEventListener("click", clearSelection);
+  map.on("zoomend", () => {
+    updateZipZoomMessage();
+    if (propertyTileLayer) {
+      renderTileLayer();
+    }
+  });
   initializeDashboard();
 });

--- a/ui/reviewer/main.js
+++ b/ui/reviewer/main.js
@@ -32,6 +32,26 @@ const GAP_BINS = [
   { min: 50, max: 75, label: "+50% to +75%", color: "#b9793f" },
   { min: 75, label: "&gt; +75%", color: "#87552c" },
 ];
+const ZIP_FOCUS_ZOOM = 14;
+const ZIP_CENTERS = {
+  19102: [39.9522, -75.1659],
+  19103: [39.9529, -75.1741],
+  19104: [39.9584, -75.2022],
+  19106: [39.9487, -75.1458],
+  19107: [39.9488, -75.159],
+  19121: [39.9813, -75.1742],
+  19122: [39.9774, -75.1458],
+  19123: [39.9635, -75.148],
+  19125: [39.9789, -75.1251],
+  19130: [39.9681, -75.1719],
+  19134: [39.9919, -75.1128],
+  19140: [40.0117, -75.1456],
+  19143: [39.9449, -75.2264],
+  19145: [39.9138, -75.1842],
+  19146: [39.9395, -75.1796],
+  19147: [39.9367, -75.1547],
+  19148: [39.9202, -75.1596],
+};
 
 const map = L.map("map", {
   zoomControl: true,
@@ -55,6 +75,12 @@ let citywideOfficialRows = [];
 let citywideModelRows = [];
 let selectedProperties = null;
 let selectedLookupPayload = null;
+let selectedZip = "";
+let activeValueBreaks = [];
+let breakCache = {
+  citywide: {},
+  zip: {},
+};
 
 const modes = {
   official: {
@@ -228,20 +254,65 @@ function computeWeightedQuantileBreaksFromBins(bins, classCount = 7) {
 }
 
 function getChoroplethBins(modeName = activeMode) {
-  const area = getAreaData();
-  const rows =
-    modeName === "estimate" ? area.modelRows : area.officialRows;
+  return getRowsForBreaks(modeName, activeGeography);
+}
+
+function getRowsForBreaks(modeName, geography) {
   const fallbackRows =
     modeName === "estimate" ? citywideModelRows : citywideOfficialRows;
+
+  if (geography === "citywide") {
+    return fallbackRows;
+  }
+
+  const area = zipContext?.areas?.[normalizeZip(geography)];
+  const rows =
+    modeName === "estimate"
+      ? normalizeBinRows(area?.model?.bins || [])
+      : normalizeBinRows(area?.official?.bins || []);
 
   return rows.length > 0 ? rows : fallbackRows;
 }
 
-function getValueClassBreaks(modeName = activeMode) {
-  return computeWeightedQuantileBreaksFromBins(
-    getChoroplethBins(modeName),
-    VALUE_COLORS.length,
-  );
+function getCachedBreaks(modeName, geography) {
+  if (modeName === "gap") {
+    return [];
+  }
+
+  if (geography === "citywide") {
+    if (!breakCache.citywide[modeName]) {
+      breakCache.citywide[modeName] = computeWeightedQuantileBreaksFromBins(
+        getRowsForBreaks(modeName, "citywide"),
+        VALUE_COLORS.length,
+      );
+    }
+
+    return breakCache.citywide[modeName];
+  }
+
+  const zipCode = normalizeZip(geography);
+  breakCache.zip[zipCode] = breakCache.zip[zipCode] || {};
+
+  if (!breakCache.zip[zipCode][modeName]) {
+    breakCache.zip[zipCode][modeName] = computeWeightedQuantileBreaksFromBins(
+      getRowsForBreaks(modeName, zipCode),
+      VALUE_COLORS.length,
+    );
+  }
+
+  return breakCache.zip[zipCode][modeName];
+}
+
+function updateActiveStyleState() {
+  selectedZip = activeGeography === "citywide" ? "" : normalizeZip(activeGeography);
+  activeValueBreaks = getCachedBreaks(activeMode, activeGeography);
+}
+
+function resetBreakCache() {
+  breakCache = {
+    citywide: {},
+    zip: {},
+  };
 }
 
 function getGapBin(value) {
@@ -267,7 +338,7 @@ function getColor(value, modeName = activeMode) {
     return gapBin ? gapBin.color : GAP_UNAVAILABLE_COLOR;
   }
 
-  const classBreaks = getValueClassBreaks(modeName);
+  const classBreaks = modeName === activeMode ? activeValueBreaks : [];
 
   if (!Number.isFinite(number)) {
     return "#cfd6df";
@@ -289,10 +360,7 @@ function getColor(value, modeName = activeMode) {
 
 function styleFeature(properties) {
   const value = getTilePropertyValue(properties);
-  const featureZip = getFeatureZip(properties);
-  const outsideSelectedZip =
-    activeGeography !== "citywide" &&
-    featureZip !== normalizeZip(activeGeography);
+  const outsideSelectedZip = selectedZip && getFeatureZip(properties) !== selectedZip;
   const gapUnavailable = activeMode === "gap" && !Number.isFinite(Number(value));
 
   return {
@@ -318,9 +386,77 @@ function getTileConfig() {
   };
 }
 
+function getZipBounds(zipCode) {
+  const bounds = zipContext?.areas?.[zipCode]?.bounds;
+
+  if (Array.isArray(bounds) && bounds.length === 2) {
+    return L.latLngBounds(bounds);
+  }
+
+  if (
+    bounds &&
+    Number.isFinite(Number(bounds.south)) &&
+    Number.isFinite(Number(bounds.west)) &&
+    Number.isFinite(Number(bounds.north)) &&
+    Number.isFinite(Number(bounds.east))
+  ) {
+    return L.latLngBounds(
+      [Number(bounds.south), Number(bounds.west)],
+      [Number(bounds.north), Number(bounds.east)],
+    );
+  }
+
+  return null;
+}
+
+function getZipCenter(zipCode) {
+  const center = zipContext?.areas?.[zipCode]?.center;
+
+  if (Array.isArray(center) && center.length === 2) {
+    return [Number(center[0]), Number(center[1])];
+  }
+
+  if (
+    center &&
+    Number.isFinite(Number(center.lat)) &&
+    Number.isFinite(Number(center.lng))
+  ) {
+    return [Number(center.lat), Number(center.lng)];
+  }
+
+  return ZIP_CENTERS[zipCode] || null;
+}
+
+function focusSelectedZip(zipCode) {
+  if (!map || !zipCode) {
+    return;
+  }
+
+  const bounds = getZipBounds(zipCode);
+
+  if (bounds?.isValid()) {
+    map.fitBounds(bounds, {
+      padding: [24, 24],
+      maxZoom: 15,
+    });
+    return;
+  }
+
+  const center = getZipCenter(zipCode);
+  const targetZoom = Math.max(map.getZoom(), ZIP_FOCUS_ZOOM);
+
+  if (center) {
+    map.flyTo(center, targetZoom, {
+      animate: true,
+    });
+    return;
+  }
+
+  map.setZoom(targetZoom);
+}
+
 function renderLegend() {
   const mode = modes[activeMode];
-  const valueClassBreaks = getValueClassBreaks();
 
   if (!legendControl) {
     legendControl = L.control({ position: "bottomright" });
@@ -344,8 +480,8 @@ function renderLegend() {
           `,
         )
       : mode.colors.map((color, index) => {
-          const lower = valueClassBreaks[index];
-          const upper = valueClassBreaks[index + 1];
+          const lower = activeValueBreaks[index];
+          const upper = activeValueBreaks[index + 1];
           const label =
             index === mode.colors.length - 1
               ? `${formatModeValue(lower)}+`
@@ -417,10 +553,7 @@ function renderTileLayer() {
   propertyTileLayer.on("click", (event) => {
     const properties = event.layer.properties;
 
-    if (
-      activeGeography !== "citywide" &&
-      getFeatureZip(properties) !== normalizeZip(activeGeography)
-    ) {
+    if (selectedZip && getFeatureZip(properties) !== selectedZip) {
       setStatus(`That property is outside ZIP ${activeGeography}.`);
       return;
     }
@@ -694,6 +827,7 @@ function renderModeControls() {
   document.querySelectorAll(".mode-button").forEach((button) => {
     button.classList.toggle("active", button.dataset.mode === activeMode);
   });
+  updateActiveStyleState();
   updateSummary();
   renderLegend();
 
@@ -902,6 +1036,7 @@ async function loadDistributionInputs() {
     officialPayload.filter((row) => Number(row.tax_year) === latestTaxYear),
   );
   citywideModelRows = normalizeBinRows(modelPayload);
+  resetBreakCache();
 }
 
 async function initializeDashboard() {
@@ -919,6 +1054,7 @@ async function initializeDashboard() {
     zipContext = await zipResponse.json();
     await loadDistributionInputs();
     populateGeographySelect();
+    updateActiveStyleState();
     updateSummary();
     updateCharts();
     renderTileLayer();
@@ -931,6 +1067,7 @@ async function initializeDashboard() {
     );
     metadata = metadata || {};
     zipContext = zipContext || { areas: {} };
+    updateActiveStyleState();
     updateSummary();
     renderTileLayer();
   }
@@ -945,13 +1082,18 @@ document.addEventListener("DOMContentLoaded", () => {
   });
 
   document.getElementById("geographySelect").addEventListener("change", (event) => {
+    const previousGeography = activeGeography;
     activeGeography = event.target.value;
+    updateActiveStyleState();
     if (
       selectedProperties &&
-      activeGeography !== "citywide" &&
-      getFeatureZip(selectedProperties) !== normalizeZip(activeGeography)
+      selectedZip &&
+      getFeatureZip(selectedProperties) !== selectedZip
     ) {
       clearSelection();
+    }
+    if (selectedZip && previousGeography !== activeGeography) {
+      focusSelectedZip(selectedZip);
     }
     updateSummary();
     updateCharts();

--- a/ui/reviewer/main.js
+++ b/ui/reviewer/main.js
@@ -32,10 +32,10 @@ const GAP_BINS = [
   { min: 50, max: 75, label: "+50% to +75%", color: "#b9793f" },
   { min: 75, label: "&gt; +75%", color: "#87552c" },
 ];
-const ZIP_FOCUS_ZOOM = 14;
+const ZIP_FOCUS_ZOOM = 16;
 const ZIP_CENTERS = {
   19102: [39.9522, -75.1659],
-  19103: [39.9529, -75.1741],
+  19103: [39.9526, -75.174],
   19104: [39.9584, -75.2022],
   19106: [39.9487, -75.1458],
   19107: [39.9488, -75.159],
@@ -363,12 +363,23 @@ function styleFeature(properties) {
   const outsideSelectedZip = selectedZip && getFeatureZip(properties) !== selectedZip;
   const gapUnavailable = activeMode === "gap" && !Number.isFinite(Number(value));
 
+  if (outsideSelectedZip) {
+    return {
+      fill: true,
+      fillColor: "#ffffff",
+      fillOpacity: 0,
+      color: "#ffffff",
+      opacity: 0,
+      weight: 0,
+    };
+  }
+
   return {
     fill: true,
-    fillColor: outsideSelectedZip ? "#d9dde5" : getColor(value),
-    fillOpacity: outsideSelectedZip || gapUnavailable ? 0.2 : 0.72,
+    fillColor: getColor(value),
+    fillOpacity: gapUnavailable ? 0.2 : 0.72,
     color: "#ffffff",
-    opacity: outsideSelectedZip ? 0.1 : 0.35,
+    opacity: 0.35,
     weight: 0.45,
   };
 }
@@ -433,26 +444,16 @@ function focusSelectedZip(zipCode) {
   }
 
   const bounds = getZipBounds(zipCode);
-
-  if (bounds?.isValid()) {
-    map.fitBounds(bounds, {
-      padding: [24, 24],
-      maxZoom: 15,
-    });
-    return;
-  }
-
-  const center = getZipCenter(zipCode);
-  const targetZoom = Math.max(map.getZoom(), ZIP_FOCUS_ZOOM);
+  const center = getZipCenter(zipCode) || (bounds?.isValid() ? bounds.getCenter() : null);
 
   if (center) {
-    map.flyTo(center, targetZoom, {
+    map.flyTo(center, ZIP_FOCUS_ZOOM, {
       animate: true,
     });
     return;
   }
 
-  map.setZoom(targetZoom);
+  map.setZoom(ZIP_FOCUS_ZOOM);
 }
 
 function renderLegend() {
@@ -521,6 +522,11 @@ function renderTileLayer() {
 
   propertyTileLayer.on("mouseover", (event) => {
     const properties = event.layer.properties;
+
+    if (selectedZip && getFeatureZip(properties) !== selectedZip) {
+      return;
+    }
+
     const value = getTilePropertyValue(properties);
     const featureZip = getFeatureZip(properties);
     const gapLine =

--- a/ui/reviewer/style.css
+++ b/ui/reviewer/style.css
@@ -2,331 +2,285 @@
   box-sizing: border-box;
 }
 
+:root {
+  --bg: #eef1f5;
+  --surface: #ffffff;
+  --surface-soft: #f7f9fb;
+  --border: #cfd6df;
+  --border-soft: #e3e7ed;
+  --text: #1d2733;
+  --muted: #5d6875;
+  --heading: #0f2438;
+  --accent: #1f5f99;
+}
+
 body {
   margin: 0;
-  font-family: Arial, sans-serif;
-  background: #f3f4f6;
-  color: #1f2937;
+  background: var(--bg);
+  color: var(--text);
+  font-family: Arial, Helvetica, sans-serif;
 }
 
-.topbar {
-  background: #fff;
-  border-bottom: 1px solid #dcdfe4;
-  padding: 20px 24px;
+.reviewer-page {
+  display: grid;
+  grid-template-columns: minmax(0, 68%) minmax(360px, 32%);
+  min-height: 100vh;
 }
 
-.topbar h1 {
-  margin: 0 0 8px;
-  font-size: 2.2rem;
+.map-panel {
+  position: relative;
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  padding: 16px;
 }
 
-.topbar p {
+.map-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 12px;
+}
+
+.eyebrow {
+  margin: 0 0 4px;
+  color: var(--accent);
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+h3 {
+  color: var(--heading);
+}
+
+h1 {
   margin: 0;
-  color: #6b7280;
+  font-size: 1.7rem;
+}
+
+h2 {
+  margin: 0 0 10px;
+  font-size: 1.45rem;
+}
+
+h3 {
+  margin: 0 0 6px;
   font-size: 1rem;
 }
 
-.page {
-  max-width: 1500px;
-  margin: 0 auto;
-  padding: 20px 24px 28px;
-  overflow-x: hidden;
-}
-
-.filters {
+.mode-toggle {
   display: flex;
-  gap: 14px;
-  margin-bottom: 24px;
-  padding: 10px 14px;
-  background: #fff;
-  border-radius: 14px;
-  border: 1px solid #e5e7eb;
+  flex-wrap: wrap;
+  gap: 8px;
+  justify-content: flex-end;
 }
 
-.filters select {
-  padding: 12px 16px;
-  border: 1px solid #d1d5db;
-  border-radius: 10px;
-  background: #f9fafb;
-  font-size: 0.95rem;
-  color: #111827;
+.mode-button,
+.text-button {
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: var(--surface);
+  color: var(--text);
+  cursor: pointer;
+  font-weight: 700;
 }
 
-.dashboard-top {
-  display: grid;
-  grid-template-columns: minmax(0, 2.2fr) 380px;
-  gap: 20px;
-  align-items: stretch;
-  margin-bottom: 20px;
+.mode-button {
+  padding: 9px 12px;
 }
 
-.dashboard-bottom {
-  display: grid;
-  grid-template-columns: 1fr;
-  gap: 20px;
-}
-
-.card {
-  background: #fff;
-  border: 1px solid #e5e7eb;
-  border-radius: 16px;
-  padding: 22px;
-  box-shadow: 0 1px 4px rgb(0 0 0 / 4%);
-}
-
-.card h2 {
-  margin: 0 0 16px;
-  font-size: 1.8rem;
-}
-
-.card-header {
-  margin-bottom: 14px;
-}
-
-.card-header h2 {
-  margin-bottom: 6px;
-}
-
-.card-header p {
-  margin: 0;
-  color: #6b7280;
-}
-
-.card-subtitle {
-  margin: -6px 0 16px;
-  color: #6b7280;
-  font-size: 0.98rem;
-}
-
-.summary-card {
-  flex: 0 0 290px;
-  width: 100%;
+.mode-button.active {
+  border-color: var(--accent);
+  background: var(--accent);
+  color: #ffffff;
 }
 
 #map {
-  width: 100%;
-  height: 620px;
-  border-radius: 12px;
-  overflow: hidden;
-  border: 1px solid #e5e7eb;
-}
-
-.summary-list {
-  display: flex;
-  flex-direction: column;
-  gap: 18px;
-}
-
-.summary-list p {
-  margin: 0;
-  display: flex;
-  justify-content: space-between;
-  gap: 16px;
-  padding-bottom: 16px;
-  border-bottom: 1px solid #edf0f3;
-}
-
-.summary-list span {
-  color: #6b7280;
-}
-
-.summary-list strong {
-  font-size: 1.08rem;
-}
-
-.distribution-card {
-  min-height: 500px;
-  overflow: hidden;
-}
-
-.chart-shell {
-  display: grid;
-  grid-template-columns: 64px 1fr;
-  gap: 12px;
-  align-items: stretch;
-}
-
-.chart-yaxis {
-  height: 340px;
-  display: flex;
-  flex-direction: column;
-  justify-content: space-between;
-  align-items: flex-end;
-  padding: 4px 0 54px;
-  color: #475569;
-  font-size: 11px;
-}
-
-.chart-area {
-  width: 100%;
-  max-width: 100%;
-  overflow: auto hidden;
-  border: 1px dashed #cbd5e1;
-  border-radius: 12px;
-  background: #fafafa;
-  padding: 16px 12px 12px;
-}
-
-.chart-note {
-  margin-top: 14px;
-  color: #4b5563;
-  font-size: 0.95rem;
-}
-
-.histogram-bars {
-  height: 340px;
-  display: flex;
-  align-items: end;
-  gap: 4px;
-  min-width: max-content;
-  padding-left: 28px;
-  padding-right: 16px;
-}
-
-.histogram-group {
-  width: 14px;
-  height: 100%;
-  display: flex;
-  flex-direction: column;
-  justify-content: end;
-  align-items: center;
-  gap: 8px;
-  flex-shrink: 0;
-}
-
-.histogram-bar {
-  width: 100%;
-  background: #688898;
-  border-radius: 3px 3px 0 0;
-  min-height: 3px;
-}
-
-.histogram-bar:hover {
-  background: #55717f;
-}
-
-.histogram-label {
-  font-size: 11px;
-  color: #475569;
-  line-height: 1.1;
-  white-space: nowrap;
-  transform: rotate(45deg);
-  transform-origin: top left;
-  min-height: 54px;
-}
-
-.empty-chart {
-  min-height: 180px;
-  border: 1px dashed #c4c9d1;
-  border-radius: 12px;
-  background: #fafafa;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  color: #6b7280;
-}
-
-.side-panel {
-  display: flex;
-  flex-direction: column;
-  gap: 20px;
-  width: 100%;
-  height: 100%;
-}
-
-.side-panel .card {
-  width: 100%;
-}
-
-.legend-card {
+  min-height: 720px;
   flex: 1;
-  width: 100%;
+  overflow: hidden;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: var(--surface-soft);
+}
+
+.status-text {
+  position: absolute;
+  left: 28px;
+  bottom: 28px;
+  z-index: 500;
+  margin: 0;
+  padding: 8px 10px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: rgb(255 255 255 / 92%);
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.status-text:empty {
+  display: none;
+}
+
+.sidebar {
+  overflow-y: auto;
+  border-left: 1px solid var(--border);
+  background: var(--surface);
+}
+
+.sidebar-section {
   padding: 22px;
 }
 
-.legend-card h2 {
-  margin: 0 0 16px;
-  color: #061a33;
-  font-size: 1.25rem;
+.sidebar-copy,
+.helper-text,
+.instruction-text {
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.5;
+}
+
+.summary-grid,
+.detail-list {
+  margin: 18px 0;
+}
+
+.summary-grid div,
+.detail-list div {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 10px 0;
+  border-bottom: 1px solid var(--border-soft);
+}
+
+.summary-grid dt,
+.detail-list dt {
+  color: var(--muted);
+}
+
+.summary-grid dd,
+.detail-list dd {
+  margin: 0;
+  color: var(--text);
+  font-weight: 800;
+  text-align: right;
+}
+
+.chart-card {
+  margin-top: 16px;
+  padding: 14px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--surface-soft);
+}
+
+.mini-chart {
+  min-height: 220px;
+  overflow: hidden;
+}
+
+.mini-chart .apexcharts-canvas {
+  max-width: 100%;
+}
+
+.instruction-text {
+  margin-top: 16px;
+  padding-top: 14px;
+  border-top: 1px solid var(--border-soft);
+  font-size: 0.92rem;
+}
+
+.text-button {
+  margin-bottom: 18px;
+  padding: 8px 12px;
+}
+
+.text-button:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+.map-legend {
+  min-width: 190px;
+  padding: 10px 12px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: rgb(255 255 255 / 94%);
+  color: var(--text);
+  box-shadow: 0 2px 10px rgb(0 0 0 / 8%);
+  font-size: 0.82rem;
+}
+
+.map-legend strong {
+  display: block;
+  margin-bottom: 8px;
 }
 
 .legend-row {
   display: flex;
   align-items: center;
-  gap: 12px;
-  margin: 12px 0;
-  color: #1f2937;
-  font-size: 0.95rem;
+  gap: 8px;
+  margin: 5px 0;
 }
 
-.legend-color {
+.legend-row span {
   display: inline-block;
-  width: 32px;
-  height: 18px;
-  border: 1px solid rgb(0 0 0 / 15%);
-  border-radius: 5px;
+  width: 26px;
+  height: 14px;
+  border: 1px solid rgb(0 0 0 / 14%);
+  border-radius: 3px;
 }
 
-.legend-1 {
-  background: #fee5d9;
+.legend-row em {
+  color: var(--muted);
+  font-style: normal;
 }
 
-.legend-2 {
-  background: #fcae91;
+.hover-popup .leaflet-popup-content-wrapper {
+  border-radius: 8px;
 }
 
-.legend-3 {
-  background: #fb6a4a;
+.hover-popup .leaflet-popup-content {
+  margin: 10px 12px;
+  line-height: 1.45;
 }
 
-.legend-4 {
-  background: #de2d26;
+[hidden] {
+  display: none !important;
 }
 
-.legend-5 {
-  background: #a50f15;
-}
-
-.legend-6 {
-  background: #67000d;
-}
-
-@media (width <= 1024px) {
-  .dashboard-top {
+@media (width <= 980px) {
+  .reviewer-page {
     grid-template-columns: 1fr;
   }
 
-  .side-panel {
-    height: auto;
-  }
-
-  .summary-card {
-    flex: initial;
+  .sidebar {
+    border-top: 1px solid var(--border);
+    border-left: none;
   }
 
   #map {
-    height: 420px;
-  }
-
-  .chart-shell {
-    grid-template-columns: 1fr;
-  }
-
-  .chart-yaxis {
-    display: none;
+    min-height: 520px;
   }
 }
 
-@media (width <= 768px) {
-  .page {
-    padding: 16px 16px 24px;
-  }
-
-  .topbar {
-    padding: 16px;
-  }
-
-  .filters {
+@media (width <= 680px) {
+  .map-toolbar {
+    align-items: flex-start;
     flex-direction: column;
+  }
+
+  .mode-toggle {
+    justify-content: flex-start;
+  }
+
+  .sidebar-section {
+    padding: 16px;
   }
 }

--- a/ui/reviewer/style.css
+++ b/ui/reviewer/style.css
@@ -154,21 +154,6 @@ h3 {
   display: none;
 }
 
-.zip-zoom-message {
-  position: absolute;
-  top: 84px;
-  left: 28px;
-  z-index: 500;
-  margin: 0;
-  padding: 8px 10px;
-  border: 1px solid #c8d7e6;
-  border-radius: 6px;
-  background: rgb(248 251 255 / 94%);
-  color: var(--accent);
-  font-size: 0.9rem;
-  font-weight: 700;
-}
-
 .sidebar {
   overflow-y: auto;
   border-left: 1px solid var(--border);

--- a/ui/reviewer/style.css
+++ b/ui/reviewer/style.css
@@ -80,6 +80,32 @@ h3 {
   justify-content: flex-end;
 }
 
+.toolbar-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  justify-content: flex-end;
+}
+
+.geography-control {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--muted);
+  font-size: 0.9rem;
+  font-weight: 700;
+}
+
+.geography-control select {
+  min-height: 38px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  padding: 8px 12px;
+  background: var(--surface);
+  color: var(--text);
+  font-weight: 700;
+}
+
 .mode-button,
 .text-button {
   border: 1px solid var(--border);
@@ -277,6 +303,10 @@ h3 {
   }
 
   .mode-toggle {
+    justify-content: flex-start;
+  }
+
+  .toolbar-controls {
     justify-content: flex-start;
   }
 

--- a/ui/reviewer/style.css
+++ b/ui/reviewer/style.css
@@ -60,7 +60,7 @@ h3 {
 
 h1 {
   margin: 0;
-  font-size: 1.7rem;
+  font-size: 1.45rem;
 }
 
 h2 {
@@ -76,14 +76,14 @@ h3 {
 .mode-toggle {
   display: flex;
   flex-wrap: wrap;
-  gap: 8px;
+  gap: 6px;
   justify-content: flex-end;
 }
 
 .toolbar-controls {
   display: flex;
   flex-wrap: wrap;
-  gap: 10px;
+  gap: 8px;
   justify-content: flex-end;
 }
 
@@ -92,15 +92,15 @@ h3 {
   align-items: center;
   gap: 8px;
   color: var(--muted);
-  font-size: 0.9rem;
+  font-size: 0.82rem;
   font-weight: 700;
 }
 
 .geography-control select {
-  min-height: 38px;
+  min-height: 34px;
   border: 1px solid var(--border);
   border-radius: 999px;
-  padding: 8px 12px;
+  padding: 6px 10px;
   background: var(--surface);
   color: var(--text);
   font-weight: 700;
@@ -117,7 +117,8 @@ h3 {
 }
 
 .mode-button {
-  padding: 9px 12px;
+  padding: 7px 10px;
+  font-size: 0.86rem;
 }
 
 .mode-button.active {
@@ -153,6 +154,21 @@ h3 {
   display: none;
 }
 
+.zip-zoom-message {
+  position: absolute;
+  top: 84px;
+  left: 28px;
+  z-index: 500;
+  margin: 0;
+  padding: 8px 10px;
+  border: 1px solid #c8d7e6;
+  border-radius: 6px;
+  background: rgb(248 251 255 / 94%);
+  color: var(--accent);
+  font-size: 0.9rem;
+  font-weight: 700;
+}
+
 .sidebar {
   overflow-y: auto;
   border-left: 1px solid var(--border);
@@ -173,7 +189,7 @@ h3 {
 
 .summary-grid,
 .detail-list {
-  margin: 18px 0;
+  margin: 14px 0;
 }
 
 .summary-grid div,
@@ -181,8 +197,15 @@ h3 {
   display: flex;
   justify-content: space-between;
   gap: 16px;
-  padding: 10px 0;
+  padding: 8px 0;
   border-bottom: 1px solid var(--border-soft);
+}
+
+.summary-grid {
+  padding: 4px 12px;
+  border: 1px solid var(--border-soft);
+  border-radius: 8px;
+  background: #fbfcfd;
 }
 
 .summary-grid dt,
@@ -204,6 +227,16 @@ h3 {
   border: 1px solid var(--border);
   border-radius: 8px;
   background: var(--surface-soft);
+}
+
+.chart-card-primary {
+  border-color: #b6cbe1;
+  background: #f8fbff;
+}
+
+.chart-card-secondary {
+  border-color: var(--border-soft);
+  background: #fbfcfd;
 }
 
 .mini-chart {
@@ -230,6 +263,32 @@ h3 {
 .text-button:hover {
   border-color: var(--accent);
   color: var(--accent);
+}
+
+.selected-group {
+  margin-bottom: 16px;
+}
+
+.selected-group h3 {
+  margin-top: 0;
+  padding-top: 12px;
+  border-top: 1px solid var(--border-soft);
+}
+
+#selectedGapValue {
+  font-variant-numeric: tabular-nums;
+}
+
+.gap-positive {
+  color: #87552c;
+}
+
+.gap-negative {
+  color: var(--accent);
+}
+
+.gap-neutral {
+  color: var(--muted);
 }
 
 .map-legend {

--- a/ui/widget/index.html
+++ b/ui/widget/index.html
@@ -1,121 +1,120 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Historical Assessment Value Widget</title>
-    <link rel="stylesheet" href="https://unpkg.com/leaflet/dist/leaflet.css" />
-    <link rel="stylesheet" href="./style.css" />
-  </head>
-  <script src="https://unpkg.com/leaflet/dist/leaflet.js"></script>
-  <script src="./main.js"></script>
-  <body>
-    <main class="widget-page">
-      <header class="widget-header">
-        <p class="eyebrow">Property assessments</p>
-        <h1>Historical Assessment Value</h1>
-        <p class="intro">
-          View historical assessment values for a selected property using its
-          OPA ID.
-        </p>
-      </header>
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Property Assessment Viewer</title>
 
-      <section class="lookup-panel" aria-label="Property lookup">
-        <label for="opaIdInput" class="input-label">OPA ID</label>
-        <div class="lookup-row">
-          <input
-            id="opaIdInput"
-            type="text"
-            inputmode="numeric"
-            placeholder="Enter OPA ID (e.g., 123456700)"
-            aria-describedby="opaIdHelp"
-          />
-          <button id="searchBtn" type="button">Look up property</button>
+  <link rel="stylesheet" href="https://unpkg.com/leaflet/dist/leaflet.css" />
+  <link rel="stylesheet" href="./style.css" />
+</head>
+<body>
+  <main class="widget-page">
+    <header class="widget-header">
+      <p class="eyebrow">Philadelphia CAMA</p>
+      <h1>Property Assessment Viewer</h1>
+      <p class="intro">
+        Look up a sample property assessment history and compare it with
+        citywide assessment distributions.
+      </p>
+    </header>
+
+    <section class="lookup-panel" aria-label="Property lookup">
+      <label for="opaIdInput" class="input-label">OPA ID</label>
+      <div class="lookup-row">
+        <input
+          id="opaIdInput"
+          type="text"
+          inputmode="numeric"
+          placeholder="Enter sample OPA ID (e.g., 502244720)"
+          aria-describedby="opaIdHelp lookupMessage"
+        />
+        <button id="searchBtn" type="button">Look up property</button>
+      </div>
+      <p id="opaIdHelp" class="helper-text">
+        This static demo uses sample property data. Try OPA ID 502244720.
+      </p>
+      <p id="lookupMessage" class="lookup-message" role="status" aria-live="polite"></p>
+    </section>
+
+    <section class="main-grid">
+      <article class="card summary-card" aria-labelledby="summary-heading">
+        <h2 id="summary-heading">Property summary</h2>
+        <dl class="summary-list">
+          <div class="summary-row">
+            <dt>OPA ID</dt>
+            <dd id="opaIdText">-</dd>
+          </div>
+          <div class="summary-row">
+            <dt>Address</dt>
+            <dd id="addressText">-</dd>
+          </div>
+          <div class="summary-row">
+            <dt>Current assessment</dt>
+            <dd id="currentValueText">-</dd>
+          </div>
+          <div class="summary-row">
+            <dt>Tax year</dt>
+            <dd id="taxYearText">-</dd>
+          </div>
+          <div class="summary-row">
+            <dt>Neighborhood</dt>
+            <dd id="neighborhoodText">-</dd>
+          </div>
+        </dl>
+      </article>
+
+      <article class="card map-card" aria-labelledby="map-heading">
+        <div class="card-header">
+          <h2 id="map-heading">Map</h2>
+          <p>Property location and surrounding context</p>
         </div>
-        <p id="opaIdHelp" class="helper-text">
-          Enter a 9–10 digit OPA identifier to load property assessment history.
-        </p>
-      </section>
+        <div id="map"></div>
+      </article>
+    </section>
 
-      <section class="content-grid">
-        <article class="card summary-card" aria-labelledby="summary-heading">
-          <h2 id="summary-heading">Property summary</h2>
-          <dl class="summary-list">
-            <div class="summary-row">
-              <dt>OPA ID</dt>
-              <dd id="opaIdText">123456700</dd>
-            </div>
-            <div class="summary-row">
-              <dt>Address</dt>
-              <dd id="addressText">123 Market St</dd>
-            </div>
-            <div class="summary-row">
-              <dt>Current assessment</dt>
-              <dd id="currentValueText">$320,000</dd>
-            </div>
-            <div class="summary-row">
-              <dt>Tax year</dt>
-              <dd id="taxYearText">2025</dd>
-            </div>
-            <div class="summary-row">
-              <dt>Neighborhood</dt>
-              <dd id="neighborhoodText">Center City</dd>
-            </div>
-          </dl>
-        </article>
+    <section class="bottom-grid">
+      <article class="card history-card" aria-labelledby="history-heading">
+        <div class="card-header">
+          <h2 id="history-heading">Assessment history</h2>
+          <p>Historical assessed values by tax year for the selected sample property</p>
+        </div>
+        <div id="assessmentHistoryChart" class="history-chart" aria-live="polite"></div>
+      </article>
 
-        <article class="card map-card" aria-labelledby="map-heading">
-          <div class="card-header">
-            <h2 id="map-heading">Map</h2>
-            <p>Property location and surrounding context</p>
-          </div>
-          <div id="map"></div>
-        </article>
-      </section>
-
-      <section class="bottom-grid">
-        <article class="card trend-card" aria-labelledby="trend-heading">
-          <div class="card-header">
-            <h2 id="trend-heading">Assessment history</h2>
-            <p>Historical assessed values by tax year</p>
-          </div>
-          <div class="trend-placeholder" aria-hidden="true">
-            <div class="bar-group">
-              <div class="bar" style="height: 38%"></div>
-              <span>2021</span>
-            </div>
-            <div class="bar-group">
-              <div class="bar" style="height: 48%"></div>
-              <span>2022</span>
-            </div>
-            <div class="bar-group">
-              <div class="bar" style="height: 58%"></div>
-              <span>2023</span>
-            </div>
-            <div class="bar-group">
-              <div class="bar" style="height: 70%"></div>
-              <span>2024</span>
-            </div>
-            <div class="bar-group">
-              <div class="bar" style="height: 82%"></div>
-              <span>2025</span>
-            </div>
-          </div>
-        </article>
-
-        <article class="card notes-card" aria-labelledby="notes-heading">
-          <div class="card-header">
-            <h2 id="notes-heading">Notes</h2>
-            <p>Placeholder space for assessment context or methodology</p>
-          </div>
-          <p class="notes-text">
-            This area can be used later for explanatory text, metadata, or
-            links to assessment records.
+      <article class="card distribution-card" aria-labelledby="distribution-heading">
+        <div class="card-header">
+          <h2 id="distribution-heading">Citywide assessment distribution</h2>
+          <p id="latest-assessment-chart-helper">
+            Loading citywide assessment distribution from the public data asset.
           </p>
-        </article>
-      </section>
-    </main>
+        </div>
+        <div
+          id="latest-assessment-chart-error"
+          class="chart-error"
+          role="status"
+          aria-live="polite"
+        ></div>
+        <div id="latest-assessment-chart"></div>
+      </article>
+    </section>
 
-    <script src="./main.js"></script>
-  </body>
+    <section class="card notes-card" aria-labelledby="notes-heading">
+      <div class="card-header">
+        <h2 id="notes-heading">Notes</h2>
+        <p>How this demo connects to the cloud data pipeline</p>
+      </div>
+      <p class="notes-text">
+        The property lookup, map, and assessment history use static sample data
+        for this browser-only demo. The citywide distribution chart loads from
+        the public Cloud Storage JSON file generated by the data pipeline:
+        <code>configs/tax_year_assessment_bins.json</code>.
+      </p>
+    </section>
+  </main>
+
+  <script src="https://unpkg.com/leaflet/dist/leaflet.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/apexcharts"></script>
+  <script src="./main.js"></script>
+</body>
 </html>

--- a/ui/widget/index.html
+++ b/ui/widget/index.html
@@ -68,6 +68,13 @@
         <p id="officialChangeText" class="change-text">-</p>
       </article>
 
+      <article id="contextCard" class="card context-card" aria-labelledby="context-heading" hidden>
+        <p class="section-label">Assessment context</p>
+        <h2 id="context-heading">How this compares</h2>
+        <p id="citywideContextText" class="context-text"></p>
+        <p id="zipContextText" class="context-text"></p>
+      </article>
+
       <article class="card history-card" aria-labelledby="history-heading">
         <div class="card-header">
           <h2 id="history-heading">Assessment history</h2>

--- a/ui/widget/index.html
+++ b/ui/widget/index.html
@@ -1,119 +1,100 @@
-<!DOCTYPE html>
+﻿<!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Property Assessment Viewer</title>
 
-  <link rel="stylesheet" href="https://unpkg.com/leaflet/dist/leaflet.css" />
   <link rel="stylesheet" href="./style.css" />
 </head>
 <body>
-  <main class="widget-page">
+  <main class="widget-shell">
     <header class="widget-header">
       <p class="eyebrow">Philadelphia CAMA</p>
       <h1>Property Assessment Viewer</h1>
       <p class="intro">
-        Look up a sample property assessment history and compare it with
-        citywide assessment distributions.
+        Look up an official property assessment history and compare it with an
+        informational current market estimate.
       </p>
     </header>
 
-    <section class="lookup-panel" aria-label="Property lookup">
-      <label for="opaIdInput" class="input-label">OPA ID</label>
+    <section class="lookup-card" aria-label="Property lookup">
+      <label for="opaIdInput">OPA ID or property ID</label>
       <div class="lookup-row">
         <input
           id="opaIdInput"
           type="text"
           inputmode="numeric"
-          placeholder="Enter sample OPA ID (e.g., 502244720)"
-          aria-describedby="opaIdHelp lookupMessage"
+          placeholder="Enter OPA ID"
+          aria-describedby="lookupHelp lookupMessage"
         />
-        <button id="searchBtn" type="button">Look up property</button>
+        <button id="searchBtn" type="button">Look up</button>
       </div>
-      <p id="opaIdHelp" class="helper-text">
-        This static demo uses sample property data. Try OPA ID 502244720.
+      <p id="lookupHelp" class="helper-text">
+        Enter a Philadelphia OPA property identifier to view official assessment history.
       </p>
       <p id="lookupMessage" class="lookup-message" role="status" aria-live="polite"></p>
     </section>
 
-    <section class="main-grid">
-      <article class="card summary-card" aria-labelledby="summary-heading">
-        <h2 id="summary-heading">Property summary</h2>
-        <dl class="summary-list">
-          <div class="summary-row">
+    <section id="emptyState" class="card empty-state">
+      <h2>Start with a property ID</h2>
+      <p>
+        This widget uses the project lookup API. Results will appear here after
+        a successful lookup.
+      </p>
+    </section>
+
+    <section id="resultPanel" class="result-panel" hidden>
+      <article class="card property-card" aria-labelledby="property-heading">
+        <p class="section-label">Property</p>
+        <h2 id="property-heading">-</h2>
+        <dl class="property-details">
+          <div>
             <dt>OPA ID</dt>
-            <dd id="opaIdText">-</dd>
+            <dd id="propertyIdText">-</dd>
           </div>
-          <div class="summary-row">
-            <dt>Address</dt>
-            <dd id="addressText">-</dd>
-          </div>
-          <div class="summary-row">
-            <dt>Current assessment</dt>
-            <dd id="currentValueText">-</dd>
-          </div>
-          <div class="summary-row">
-            <dt>Tax year</dt>
-            <dd id="taxYearText">-</dd>
-          </div>
-          <div class="summary-row">
-            <dt>Neighborhood</dt>
-            <dd id="neighborhoodText">-</dd>
+          <div>
+            <dt>Property type</dt>
+            <dd id="propertyTypeText">-</dd>
           </div>
         </dl>
       </article>
 
-      <article class="card map-card" aria-labelledby="map-heading">
-        <div class="card-header">
-          <h2 id="map-heading">Map</h2>
-          <p>Property location and surrounding context</p>
-        </div>
-        <div id="map"></div>
+      <article class="card official-card" aria-labelledby="official-heading">
+        <p class="section-label">Official record</p>
+        <h2 id="official-heading">Current Official Assessed Value</h2>
+        <p id="officialValueText" class="official-value">-</p>
+        <p id="officialYearText" class="subtle-text">Tax Year -</p>
+        <p id="officialChangeText" class="change-text">-</p>
       </article>
-    </section>
 
-    <section class="bottom-grid">
       <article class="card history-card" aria-labelledby="history-heading">
         <div class="card-header">
           <h2 id="history-heading">Assessment history</h2>
-          <p>Historical assessed values by tax year for the selected sample property</p>
+          <p>Official assessed values by tax year.</p>
         </div>
         <div id="assessmentHistoryChart" class="history-chart" aria-live="polite"></div>
       </article>
 
-      <article class="card distribution-card" aria-labelledby="distribution-heading">
-        <div class="card-header">
-          <h2 id="distribution-heading">Citywide assessment distribution</h2>
-          <p id="latest-assessment-chart-helper">
-            Loading citywide assessment distribution from the public data asset.
-          </p>
-        </div>
-        <div
-          id="latest-assessment-chart-error"
-          class="chart-error"
-          role="status"
-          aria-live="polite"
-        ></div>
-        <div id="latest-assessment-chart"></div>
+      <article class="card estimate-card" aria-labelledby="estimate-heading">
+        <p class="section-label">Informational estimate</p>
+        <h2 id="estimate-heading">Estimated Current Market Value</h2>
+        <p id="estimateValueText" class="estimate-value">-</p>
+        <p id="estimateGapText" class="subtle-text">-</p>
+        <p class="estimate-note">
+          This estimate is based on recent sales data and property characteristics.
+          It is not your official assessed value and does not affect your tax bill.
+        </p>
       </article>
-    </section>
 
-    <section class="card notes-card" aria-labelledby="notes-heading">
-      <div class="card-header">
-        <h2 id="notes-heading">Notes</h2>
-        <p>How this demo connects to the cloud data pipeline</p>
-      </div>
-      <p class="notes-text">
-        The property lookup, map, and assessment history use static sample data
-        for this browser-only demo. The citywide distribution chart loads from
-        the public Cloud Storage JSON file generated by the data pipeline:
-        <code>configs/tax_year_assessment_bins.json</code>.
-      </p>
+      <footer class="source-note">
+        <p id="sourceNoteText">
+          Sources: Philadelphia OPA assessment records and CAMA model output.
+        </p>
+      </footer>
     </section>
   </main>
 
-  <script src="https://unpkg.com/leaflet/dist/leaflet.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/apexcharts"></script>
   <script src="./main.js"></script>
 </body>

--- a/ui/widget/index.html
+++ b/ui/widget/index.html
@@ -31,7 +31,8 @@
         <button id="searchBtn" type="button">Look up</button>
       </div>
       <p id="lookupHelp" class="helper-text">
-        Enter a Philadelphia OPA property identifier to view official assessment history.
+        Enter a Philadelphia OPA property ID. You can find it on a Real Estate
+        Tax bill or at atlas.phila.gov.
       </p>
       <p id="lookupMessage" class="lookup-message" role="status" aria-live="polite"></p>
     </section>
@@ -39,8 +40,8 @@
     <section id="emptyState" class="card empty-state">
       <h2>Start with a property ID</h2>
       <p>
-        This widget uses the project lookup API. Results will appear here after
-        a successful lookup.
+        Enter a Philadelphia OPA property ID to view the official assessment
+        record, recent history, and an informational market estimate.
       </p>
     </section>
 
@@ -68,19 +69,19 @@
         <p id="officialChangeText" class="change-text">-</p>
       </article>
 
-      <article id="contextCard" class="card context-card" aria-labelledby="context-heading" hidden>
-        <p class="section-label">Assessment context</p>
-        <h2 id="context-heading">How this compares</h2>
-        <p id="citywideContextText" class="context-text"></p>
-        <p id="zipContextText" class="context-text"></p>
-      </article>
-
       <article class="card history-card" aria-labelledby="history-heading">
         <div class="card-header">
           <h2 id="history-heading">Assessment history</h2>
           <p>Official assessed values by tax year.</p>
         </div>
         <div id="assessmentHistoryChart" class="history-chart" aria-live="polite"></div>
+      </article>
+
+      <article id="contextCard" class="card context-card" aria-labelledby="context-heading" hidden>
+        <p class="section-label">Assessment context</p>
+        <h2 id="context-heading">How this compares</h2>
+        <p id="citywideContextText" class="context-text"></p>
+        <p id="zipContextText" class="context-text"></p>
       </article>
 
       <article class="card estimate-card" aria-labelledby="estimate-heading">

--- a/ui/widget/index.html
+++ b/ui/widget/index.html
@@ -80,8 +80,16 @@
       <article id="contextCard" class="card context-card" aria-labelledby="context-heading" hidden>
         <p class="section-label">Assessment context</p>
         <h2 id="context-heading">How this compares</h2>
-        <p id="citywideContextText" class="context-text"></p>
-        <p id="zipContextText" class="context-text"></p>
+        <div id="citywideContextRow" class="context-row" hidden>
+          <span class="context-label">Citywide percentile</span>
+          <strong id="citywideContextValue" class="context-value">-</strong>
+          <span class="context-helper">among Philadelphia residential parcels</span>
+        </div>
+        <div id="zipContextRow" class="context-row" hidden>
+          <span class="context-label">ZIP percentile</span>
+          <strong id="zipContextValue" class="context-value">-</strong>
+          <span id="zipContextHelper" class="context-helper"></span>
+        </div>
       </article>
 
       <article class="card estimate-card" aria-labelledby="estimate-heading">

--- a/ui/widget/main.js
+++ b/ui/widget/main.js
@@ -97,14 +97,30 @@ function formatOfficialChange(official) {
     official.change_pct === null ||
     official.change_pct === undefined
   ) {
-    return "Prior-year comparison is not available.";
+    return {
+      className: "change-neutral",
+      text: "Prior-year comparison is not available.",
+    };
   }
 
-  const latest = formatMoney(official.latest_assessed_value);
   const prior = formatMoney(official.prior_assessed_value);
-  const pct = formatPercent(official.change_pct);
+  const changePct = Number(official.change_pct);
 
-  return `${latest} compared with ${prior} in Tax Year ${official.prior_tax_year} (${pct}).`;
+  if (changePct === 0) {
+    return {
+      className: "change-neutral",
+      text: `— No change from Tax Year ${official.prior_tax_year} (${prior}).`,
+    };
+  }
+
+  const direction = changePct > 0 ? "increase" : "decrease";
+  const symbol = changePct > 0 ? "▲" : "▼";
+  const className = changePct > 0 ? "change-positive" : "change-negative";
+
+  return {
+    className,
+    text: `${symbol} ${formatPercent(Math.abs(changePct))} ${direction} from Tax Year ${official.prior_tax_year} (${prior}).`,
+  };
 }
 
 function formatEstimateGap(estimate) {
@@ -246,18 +262,20 @@ function renderProperty(payload) {
     official.latest_tax_year !== null && official.latest_tax_year !== undefined
       ? `Tax Year ${official.latest_tax_year}`
       : "Tax Year not available";
-  document.getElementById("officialChangeText").textContent =
-    formatOfficialChange(official);
+  const officialChange = formatOfficialChange(official);
+  const officialChangeElement = document.getElementById("officialChangeText");
+  officialChangeElement.className = `change-text ${officialChange.className}`;
+  officialChangeElement.textContent = officialChange.text;
 
   document.getElementById("contextCard").hidden =
     !citywideOfficialPercentile && !zipOfficialPercentile;
   document.getElementById("citywideContextText").textContent =
     citywideOfficialPercentile
-      ? `This official assessed value is around the ${citywideOfficialPercentile} percentile citywide.`
+      ? `Citywide: around the ${citywideOfficialPercentile} percentile.`
       : "Citywide context is unavailable.";
   document.getElementById("zipContextText").textContent =
     zipOfficialPercentile && context.zip
-      ? `Around the ${zipOfficialPercentile} percentile among residential parcels in ${context.zip.label}.`
+      ? `${context.zip.label}: around the ${zipOfficialPercentile} percentile.`
       : "";
 
   document.getElementById("estimateValueText").textContent = formatMoney(

--- a/ui/widget/main.js
+++ b/ui/widget/main.js
@@ -47,6 +47,22 @@ function formatPercent(value) {
   }).format(number);
 }
 
+function formatPercentile(value) {
+  const number = Number(value);
+
+  if (!Number.isFinite(number)) {
+    return null;
+  }
+
+  const rounded = Math.round(number);
+  const suffix =
+    rounded % 100 >= 11 && rounded % 100 <= 13
+      ? "th"
+      : { 1: "st", 2: "nd", 3: "rd" }[rounded % 10] || "th";
+
+  return `${rounded}${suffix}`;
+}
+
 function setLookupMessage(message = "", type = "neutral") {
   const messageElement = document.getElementById("lookupMessage");
   messageElement.textContent = message;
@@ -208,6 +224,13 @@ function renderProperty(payload) {
   const property = payload.property || {};
   const official = payload.official || {};
   const estimate = payload.estimate || {};
+  const context = payload.context || {};
+  const citywideOfficialPercentile = formatPercentile(
+    context.citywide?.official_percentile,
+  );
+  const zipOfficialPercentile = formatPercentile(
+    context.zip?.official_percentile,
+  );
 
   document.getElementById("property-heading").textContent =
     property.address || "Address not available";
@@ -225,6 +248,17 @@ function renderProperty(payload) {
       : "Tax Year not available";
   document.getElementById("officialChangeText").textContent =
     formatOfficialChange(official);
+
+  document.getElementById("contextCard").hidden =
+    !citywideOfficialPercentile && !zipOfficialPercentile;
+  document.getElementById("citywideContextText").textContent =
+    citywideOfficialPercentile
+      ? `This official assessed value is around the ${citywideOfficialPercentile} percentile citywide.`
+      : "Citywide context is unavailable.";
+  document.getElementById("zipContextText").textContent =
+    zipOfficialPercentile && context.zip
+      ? `Around the ${zipOfficialPercentile} percentile among residential parcels in ${context.zip.label}.`
+      : "";
 
   document.getElementById("estimateValueText").textContent = formatMoney(
     estimate.estimated_current_market_value,

--- a/ui/widget/main.js
+++ b/ui/widget/main.js
@@ -162,7 +162,7 @@ function renderHistoryChart(history) {
 
   assessmentHistoryChart = new window.ApexCharts(chartElement, {
     chart: {
-      type: "bar",
+      type: "line",
       height: 300,
       width: "100%",
       parentHeightOffset: 0,
@@ -177,9 +177,12 @@ function renderHistoryChart(history) {
       },
     ],
     colors: ["#1f5f99"],
-    fill: {
-      type: "solid",
-      opacity: 1,
+    stroke: {
+      width: 3,
+      curve: "straight",
+    },
+    markers: {
+      size: 4,
     },
     plotOptions: {
       bar: {
@@ -269,14 +272,17 @@ function renderProperty(payload) {
 
   document.getElementById("contextCard").hidden =
     !citywideOfficialPercentile && !zipOfficialPercentile;
-  document.getElementById("citywideContextText").textContent =
-    citywideOfficialPercentile
-      ? `Citywide: around the ${citywideOfficialPercentile} percentile.`
-      : "Citywide context is unavailable.";
-  document.getElementById("zipContextText").textContent =
-    zipOfficialPercentile && context.zip
-      ? `${context.zip.label}: around the ${zipOfficialPercentile} percentile.`
-      : "";
+  document.getElementById("citywideContextRow").hidden =
+    !citywideOfficialPercentile;
+  document.getElementById("zipContextRow").hidden =
+    !zipOfficialPercentile || !context.zip;
+  document.getElementById("citywideContextValue").textContent =
+    citywideOfficialPercentile || "-";
+  document.getElementById("zipContextValue").textContent =
+    zipOfficialPercentile || "-";
+  document.getElementById("zipContextHelper").textContent = context.zip
+    ? `in ${context.zip.label}`
+    : "";
 
   document.getElementById("estimateValueText").textContent = formatMoney(
     estimate.estimated_current_market_value,

--- a/ui/widget/main.js
+++ b/ui/widget/main.js
@@ -1,116 +1,132 @@
-const SAMPLE_PROPERTIES = [
-  {
-    propertyId: "502244720",
-    address: "Sample property record",
-    neighborhood: "Philadelphia",
-    lat: 39.9526,
-    lng: -75.1652,
-    history: [
-      { year: "2015", marketValue: 169600 },
-      { year: "2016", marketValue: 169600 },
-      { year: "2017", marketValue: 169600 },
-      { year: "2018", marketValue: 169600 },
-      { year: "2019", marketValue: 167000 },
-      { year: "2020", marketValue: 169200 },
-      { year: "2021", marketValue: 169200 },
-      { year: "2022", marketValue: 169200 },
-      { year: "2023", marketValue: 185000 },
-      { year: "2024", marketValue: 185000 },
-      { year: "2025", marketValue: 306700 },
-      { year: "2026", marketValue: 306700 },
-    ],
-  },
-];
+const PROPERTY_LOOKUP_API_URL =
+  window.PROPERTY_LOOKUP_API_URL ||
+  new URLSearchParams(window.location.search).get("lookup_api_url") ||
+  "https://property-assessment-lookup-bl43esqwsa-uk.a.run.app";
 
-const TAX_YEAR_ASSESSMENT_BINS_URL =
-  "https://storage.googleapis.com/musa5090s26-team1-public/configs/tax_year_assessment_bins.json";
-const MAIN_DISPLAY_MAX = 2500000;
-const MAIN_DISPLAY_BIN_SIZE = 100000;
-const OVERFLOW_LABEL = ">$2.5M";
-const RANGE_SEPARATOR = "-";
-
-const DEFAULT_VIEW = {
-  lat: 39.9526,
-  lng: -75.1652,
-  zoom: 12,
-};
-
-let map = null;
-let marker = null;
 let assessmentHistoryChart = null;
-let latestAssessmentChart = null;
 
 function formatMoney(value) {
+  const number = Number(value);
+
+  if (!Number.isFinite(number)) {
+    return "Not available";
+  }
+
   return new Intl.NumberFormat("en-US", {
     style: "currency",
     currency: "USD",
     maximumFractionDigits: 0,
-  }).format(value);
+  }).format(number);
 }
 
 function formatCompactCurrency(value) {
+  const number = Number(value);
+
+  if (!Number.isFinite(number)) {
+    return "-";
+  }
+
   return new Intl.NumberFormat("en-US", {
     style: "currency",
     currency: "USD",
     notation: "compact",
     maximumFractionDigits: 1,
-  }).format(value);
+  }).format(number);
 }
 
-function formatNumber(value) {
-  return new Intl.NumberFormat("en-US").format(value);
+function formatPercent(value) {
+  const number = Number(value);
+
+  if (!Number.isFinite(number)) {
+    return "Not available";
+  }
+
+  return new Intl.NumberFormat("en-US", {
+    style: "percent",
+    maximumFractionDigits: 1,
+  }).format(number);
 }
 
-function initializeMap() {
-  map = L.map("map").setView(
-    [DEFAULT_VIEW.lat, DEFAULT_VIEW.lng],
-    DEFAULT_VIEW.zoom,
-  );
-
-  L.tileLayer("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png", {
-    attribution: "&copy; OpenStreetMap contributors",
-  }).addTo(map);
+function setLookupMessage(message = "", type = "neutral") {
+  const messageElement = document.getElementById("lookupMessage");
+  messageElement.textContent = message;
+  messageElement.dataset.type = type;
 }
 
-function setLookupMessage(message = "") {
-  document.getElementById("lookupMessage").textContent = message;
+function setLoading(isLoading) {
+  const button = document.getElementById("searchBtn");
+  const input = document.getElementById("opaIdInput");
+
+  button.disabled = isLoading;
+  input.disabled = isLoading;
+  button.textContent = isLoading ? "Looking up..." : "Look up";
 }
 
-function updateMap(property) {
-  if (!map) {
+function showEmptyState() {
+  document.getElementById("emptyState").hidden = false;
+  document.getElementById("resultPanel").hidden = true;
+}
+
+function showResultState() {
+  document.getElementById("emptyState").hidden = true;
+  document.getElementById("resultPanel").hidden = false;
+}
+
+function formatOfficialChange(official) {
+  if (
+    official.prior_tax_year === null ||
+    official.prior_tax_year === undefined ||
+    official.prior_assessed_value === null ||
+    official.prior_assessed_value === undefined ||
+    official.change_pct === null ||
+    official.change_pct === undefined
+  ) {
+    return "Prior-year comparison is not available.";
+  }
+
+  const latest = formatMoney(official.latest_assessed_value);
+  const prior = formatMoney(official.prior_assessed_value);
+  const pct = formatPercent(official.change_pct);
+
+  return `${latest} compared with ${prior} in Tax Year ${official.prior_tax_year} (${pct}).`;
+}
+
+function formatEstimateGap(estimate) {
+  if (
+    estimate.gap_value === null ||
+    estimate.gap_value === undefined ||
+    estimate.gap_pct === null ||
+    estimate.gap_pct === undefined
+  ) {
+    return "Comparison with the official value is not available.";
+  }
+
+  const direction = estimate.gap_value >= 0 ? "above" : "below";
+  return `${formatMoney(Math.abs(estimate.gap_value))} ${direction} the current official assessed value (${formatPercent(Math.abs(estimate.gap_pct))}).`;
+}
+
+function destroyHistoryChart() {
+  if (assessmentHistoryChart) {
+    assessmentHistoryChart.destroy();
+    assessmentHistoryChart = null;
+  }
+}
+
+function renderHistoryChart(history) {
+  const chartElement = document.getElementById("assessmentHistoryChart");
+  destroyHistoryChart();
+
+  if (!window.ApexCharts) {
+    chartElement.textContent = "Assessment history chart library failed to load.";
     return;
   }
 
-  map.setView([property.lat, property.lng], 15);
-
-  if (marker) {
-    map.removeLayer(marker);
+  if (!Array.isArray(history) || history.length === 0) {
+    chartElement.textContent = "No official assessment history is available.";
+    return;
   }
 
-  marker = L.marker([property.lat, property.lng])
-    .addTo(map)
-    .bindPopup(`${property.address}<br>OPA ID: ${property.propertyId}`)
-    .openPopup();
-}
-
-function renderSummary(property) {
-  const latest = property.history[property.history.length - 1];
-
-  document.getElementById("opaIdText").textContent = property.propertyId;
-  document.getElementById("addressText").textContent = property.address;
-  document.getElementById("currentValueText").textContent = formatMoney(
-    latest.marketValue,
-  );
-  document.getElementById("taxYearText").textContent = latest.year;
-  document.getElementById("neighborhoodText").textContent = property.neighborhood;
-}
-
-function renderAssessmentHistory(property) {
-  const chartElement = document.getElementById("assessmentHistoryChart");
-
-  if (assessmentHistoryChart) {
-    assessmentHistoryChart.destroy();
-  }
+  chartElement.textContent = "";
 
   assessmentHistoryChart = new window.ApexCharts(chartElement, {
     chart: {
@@ -124,18 +140,18 @@ function renderAssessmentHistory(property) {
     },
     series: [
       {
-        name: "Assessed value",
-        data: property.history.map((item) => Number(item.marketValue)),
+        name: "Official assessed value",
+        data: history.map((item) => Number(item.assessed_value)),
       },
     ],
-    colors: ["#0d3b66"],
+    colors: ["#1f5f99"],
     fill: {
       type: "solid",
       opacity: 1,
     },
     plotOptions: {
       bar: {
-        borderRadius: 4,
+        borderRadius: 3,
         columnWidth: "58%",
       },
     },
@@ -143,25 +159,23 @@ function renderAssessmentHistory(property) {
       enabled: false,
     },
     grid: {
-      borderColor: "#e5e7eb",
+      borderColor: "#d9dde5",
+      strokeDashArray: 3,
       padding: {
         left: 10,
         right: 12,
-        top: 6,
+        top: 8,
         bottom: 0,
       },
-      strokeDashArray: 4,
     },
     xaxis: {
-      categories: property.history.map((item) => item.year),
+      categories: history.map((item) => String(item.tax_year)),
       title: {
         text: "Tax year",
       },
       labels: {
         rotate: -45,
-        rotateAlways: false,
         trim: false,
-        hideOverlappingLabels: false,
         style: {
           fontSize: "11px",
         },
@@ -169,7 +183,7 @@ function renderAssessmentHistory(property) {
     },
     yaxis: {
       title: {
-        text: "Assessed value",
+        text: "Official assessed value",
       },
       labels: {
         minWidth: 72,
@@ -179,283 +193,99 @@ function renderAssessmentHistory(property) {
     tooltip: {
       x: {
         formatter: (_value, { dataPointIndex }) =>
-          `Tax year ${property.history[dataPointIndex].year}`,
+          `Tax Year ${history[dataPointIndex].tax_year}`,
       },
       y: {
         formatter: (value) => formatMoney(value),
-        title: {
-          formatter: () => "Assessed value:",
-        },
       },
     },
-    responsive: [
-      {
-        breakpoint: 760,
-        options: {
-          chart: {
-            height: 320,
-          },
-          plotOptions: {
-            bar: {
-              columnWidth: "66%",
-            },
-          },
-        },
-      },
-    ],
   });
 
   assessmentHistoryChart.render();
 }
 
-function renderProperty(property) {
-  renderSummary(property);
-  renderAssessmentHistory(property);
-  updateMap(property);
+function renderProperty(payload) {
+  const property = payload.property || {};
+  const official = payload.official || {};
+  const estimate = payload.estimate || {};
+
+  document.getElementById("property-heading").textContent =
+    property.address || "Address not available";
+  document.getElementById("propertyIdText").textContent =
+    property.property_id || "Not available";
+  document.getElementById("propertyTypeText").textContent =
+    property.property_type || "Not available";
+
+  document.getElementById("officialValueText").textContent = formatMoney(
+    official.latest_assessed_value,
+  );
+  document.getElementById("officialYearText").textContent =
+    official.latest_tax_year !== null && official.latest_tax_year !== undefined
+      ? `Tax Year ${official.latest_tax_year}`
+      : "Tax Year not available";
+  document.getElementById("officialChangeText").textContent =
+    formatOfficialChange(official);
+
+  document.getElementById("estimateValueText").textContent = formatMoney(
+    estimate.estimated_current_market_value,
+  );
+  document.getElementById("estimateGapText").textContent =
+    formatEstimateGap(estimate);
+
+  const estimatedAt = estimate.predicted_at
+    ? ` Estimate generated ${new Date(estimate.predicted_at).toLocaleDateString()}.`
+    : "";
+  document.getElementById("sourceNoteText").textContent =
+    `Sources: Philadelphia OPA assessment records and CAMA model output.${estimatedAt}`;
+
+  renderHistoryChart(payload.history || []);
+  showResultState();
 }
 
-function lookupProperty() {
-  const opaId = document.getElementById("opaIdInput").value.trim();
-  const property = SAMPLE_PROPERTIES.find((item) => item.propertyId === opaId);
+async function lookupProperty() {
+  const propertyId = document.getElementById("opaIdInput").value.trim();
 
-  if (!property) {
-    setLookupMessage("OPA ID not found in sample data. Try 502244720.");
+  if (!propertyId) {
+    setLookupMessage("Enter an OPA ID or property ID to continue.", "error");
     return;
   }
 
-  setLookupMessage("");
-  renderProperty(property);
-}
+  setLoading(true);
+  setLookupMessage("Looking up property record...", "neutral");
 
-function setChartError(message = "") {
-  const errorElement = document.getElementById("latest-assessment-chart-error");
-  errorElement.textContent = message;
-  errorElement.style.display = message ? "block" : "none";
-}
-
-function setChartHelperText(message) {
-  document.getElementById("latest-assessment-chart-helper").textContent = message;
-}
-
-function destroyLatestAssessmentChart() {
-  if (latestAssessmentChart) {
-    latestAssessmentChart.destroy();
-    latestAssessmentChart = null;
-  }
-}
-
-function buildDisplayBins(rows) {
-  const bins = [];
-  let lowerBound = 0;
-
-  while (lowerBound < MAIN_DISPLAY_MAX) {
-    bins.push({
-      lowerBound,
-      upperBound: lowerBound + MAIN_DISPLAY_BIN_SIZE,
-      propertyCount: 0,
-      label: "",
-      tooltipLabel: "",
-      isOverflow: false,
-    });
-    lowerBound += MAIN_DISPLAY_BIN_SIZE;
-  }
-
-  bins.push({
-    lowerBound: MAIN_DISPLAY_MAX,
-    upperBound: null,
-    propertyCount: 0,
-    label: OVERFLOW_LABEL,
-    tooltipLabel: `>${formatMoney(MAIN_DISPLAY_MAX)}`,
-    isOverflow: true,
-  });
-
-  for (const row of rows) {
-    if (row.lowerBound >= MAIN_DISPLAY_MAX || row.upperBound > MAIN_DISPLAY_MAX) {
-      bins[bins.length - 1].propertyCount += row.propertyCount;
-      continue;
-    }
-
-    const index = Math.floor(row.lowerBound / MAIN_DISPLAY_BIN_SIZE);
-    if (bins[index]) {
-      bins[index].propertyCount += row.propertyCount;
-    }
-  }
-
-  for (const bin of bins) {
-    if (bin.isOverflow) {
-      continue;
-    }
-
-    bin.tooltipLabel = `${formatMoney(bin.lowerBound)} ${RANGE_SEPARATOR} ${formatMoney(bin.upperBound - 1)}`;
-
-    if (bin.lowerBound === 0) {
-      bin.label = "$0";
-    } else if (bin.lowerBound % 500000 === 0) {
-      bin.label = formatCompactCurrency(bin.lowerBound);
-    } else {
-      bin.label = "";
-    }
-  }
-
-  return bins;
-}
-
-function renderLatestAssessmentChart(rows, latestTaxYear) {
-  const chartElement = document.getElementById("latest-assessment-chart");
-  const categories = rows.map((row) => row.label);
-  const seriesData = rows.map((row) => ({
-    x: row.label,
-    y: row.propertyCount,
-  }));
-
-  destroyLatestAssessmentChart();
-  setChartError("");
-  setChartHelperText(
-    `Latest tax year (${latestTaxYear}) distribution. Main range shown up to $2.5M; higher values grouped into an overflow bin.`,
-  );
-
-  latestAssessmentChart = new window.ApexCharts(chartElement, {
-    chart: {
-      type: "bar",
-      height: 340,
-      toolbar: {
-        show: false,
-      },
-      animations: {
-        easing: "easeinout",
-        speed: 350,
-      },
-    },
-    series: [
-      {
-        name: "Properties",
-        data: seriesData,
-      },
-    ],
-    colors: ["#0d3b66"],
-    plotOptions: {
-      bar: {
-        borderRadius: 4,
-        columnWidth: "86%",
-      },
-    },
-    dataLabels: {
-      enabled: false,
-    },
-    legend: {
-      show: false,
-    },
-    grid: {
-      borderColor: "#e5e7eb",
-      strokeDashArray: 4,
-    },
-    xaxis: {
-      categories,
-      tickPlacement: "between",
-      labels: {
-        rotate: 0,
-        trim: false,
-        hideOverlappingLabels: true,
-      },
-      title: {
-        text: "Assessed value range",
-      },
-    },
-    yaxis: {
-      title: {
-        text: "Property count",
-      },
-      labels: {
-        formatter: (value) => formatNumber(Math.round(value)),
-      },
-    },
-    tooltip: {
-      x: {
-        formatter: (_value, { dataPointIndex }) => rows[dataPointIndex].tooltipLabel,
-      },
-      y: {
-        formatter: (value) => `${formatNumber(value)} properties`,
-      },
-    },
-  });
-
-  latestAssessmentChart.render();
-}
-
-async function loadLatestAssessmentChart() {
   try {
-    setChartError("");
-    setChartHelperText("Loading citywide assessment distribution...");
+    const url = new URL(PROPERTY_LOOKUP_API_URL, window.location.origin);
+    url.searchParams.set("property_id", propertyId);
 
-    if (!window.ApexCharts) {
-      throw new Error("Assessment chart library failed to load.");
-    }
-
-    const response = await fetch(TAX_YEAR_ASSESSMENT_BINS_URL);
-    if (!response.ok) {
-      throw new Error(`Unable to load assessment chart data (${response.status}).`);
-    }
-
+    const response = await fetch(url);
     const payload = await response.json();
-    if (!Array.isArray(payload) || payload.length === 0) {
-      destroyLatestAssessmentChart();
-      setChartError("No assessment distribution data is available right now.");
+
+    if (!response.ok || !payload.ok) {
+      destroyHistoryChart();
+      showEmptyState();
+      setLookupMessage(payload.error || "Property lookup failed.", "error");
       return;
     }
 
-    const taxYears = payload
-      .map((row) => Number(row.tax_year))
-      .filter((taxYear) => Number.isFinite(taxYear));
-
-    if (taxYears.length === 0) {
-      destroyLatestAssessmentChart();
-      setChartError("Assessment distribution data is missing tax year values.");
-      return;
-    }
-
-    const latestTaxYear = Math.max(...taxYears);
-    const latestRows = payload
-      .filter((row) => Number(row.tax_year) === latestTaxYear)
-      .map((row) => ({
-        lowerBound: Number(row.lower_bound),
-        upperBound: Number(row.upper_bound),
-        propertyCount: Number(row.property_count),
-      }))
-      .filter(
-        (row) =>
-          Number.isFinite(row.lowerBound) &&
-          Number.isFinite(row.upperBound) &&
-          Number.isFinite(row.propertyCount),
-      )
-      .sort((left, right) => left.lowerBound - right.lowerBound);
-
-    if (latestRows.length === 0) {
-      destroyLatestAssessmentChart();
-      setChartError(
-        `No assessment distribution bins were found for tax year ${latestTaxYear}.`,
-      );
-      return;
-    }
-
-    renderLatestAssessmentChart(buildDisplayBins(latestRows), latestTaxYear);
+    renderProperty(payload);
+    setLookupMessage("Property record loaded.", "success");
   } catch (error) {
-    destroyLatestAssessmentChart();
-    setChartError(
+    destroyHistoryChart();
+    showEmptyState();
+    setLookupMessage(
       error instanceof Error
         ? error.message
-        : "Unable to load the latest assessment distribution chart.",
+        : "Unable to load the property record right now.",
+      "error",
     );
+  } finally {
+    setLoading(false);
   }
 }
 
 document.addEventListener("DOMContentLoaded", () => {
-  const sampleProperty = SAMPLE_PROPERTIES[0];
+  showEmptyState();
 
-  initializeMap();
-  renderProperty(sampleProperty);
-  loadLatestAssessmentChart();
-
-  document.getElementById("opaIdInput").value = sampleProperty.propertyId;
   document.getElementById("searchBtn").addEventListener("click", lookupProperty);
   document.getElementById("opaIdInput").addEventListener("keydown", (event) => {
     if (event.key === "Enter") {

--- a/ui/widget/main.js
+++ b/ui/widget/main.js
@@ -1,4 +1,4 @@
-const data = [
+const SAMPLE_PROPERTIES = [
   {
     propertyId: "502244720",
     address: "Sample property record",
@@ -22,8 +22,12 @@ const data = [
   },
 ];
 
-let map = null;
-let marker = null;
+const TAX_YEAR_ASSESSMENT_BINS_URL =
+  "https://storage.googleapis.com/musa5090s26-team1-public/configs/tax_year_assessment_bins.json";
+const MAIN_DISPLAY_MAX = 2500000;
+const MAIN_DISPLAY_BIN_SIZE = 100000;
+const OVERFLOW_LABEL = ">$2.5M";
+const RANGE_SEPARATOR = "-";
 
 const DEFAULT_VIEW = {
   lat: 39.9526,
@@ -31,8 +35,30 @@ const DEFAULT_VIEW = {
   zoom: 12,
 };
 
+let map = null;
+let marker = null;
+let assessmentHistoryChart = null;
+let latestAssessmentChart = null;
+
 function formatMoney(value) {
-  return `$${Number(value).toLocaleString()}`;
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    maximumFractionDigits: 0,
+  }).format(value);
+}
+
+function formatCompactCurrency(value) {
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    notation: "compact",
+    maximumFractionDigits: 1,
+  }).format(value);
+}
+
+function formatNumber(value) {
+  return new Intl.NumberFormat("en-US").format(value);
 }
 
 function initializeMap() {
@@ -46,8 +72,14 @@ function initializeMap() {
   }).addTo(map);
 }
 
+function setLookupMessage(message = "") {
+  document.getElementById("lookupMessage").textContent = message;
+}
+
 function updateMap(property) {
-  if (!map) return;
+  if (!map) {
+    return;
+  }
 
   map.setView([property.lat, property.lng], 15);
 
@@ -61,91 +93,373 @@ function updateMap(property) {
     .openPopup();
 }
 
-function resetSummary() {
-  document.getElementById("opaIdText").textContent = "—";
-  document.getElementById("addressText").textContent = "—";
-  document.getElementById("currentValueText").textContent = "—";
-  document.getElementById("taxYearText").textContent = "—";
-  document.getElementById("neighborhoodText").textContent = "—";
-}
-
-function resetTrend() {
-  const trendContainer = document.querySelector(".trend-placeholder");
-  trendContainer.innerHTML =
-    '<p class="empty-message">Assessment history will appear after lookup.</p>';
-}
-
-function resetView() {
-  resetSummary();
-  resetTrend();
-
-  if (map) {
-    map.setView([DEFAULT_VIEW.lat, DEFAULT_VIEW.lng], DEFAULT_VIEW.zoom);
-
-    if (marker) {
-      map.removeLayer(marker);
-      marker = null;
-    }
-  }
-}
-
-function renderTrend(property) {
-  const trendContainer = document.querySelector(".trend-placeholder");
-  trendContainer.innerHTML = "";
-
-  const maxValue = Math.max(
-    ...property.history.map((item) => Number(item.marketValue)),
-  );
-
-  property.history.forEach((item) => {
-    const group = document.createElement("div");
-    group.className = "bar-group";
-
-    const bar = document.createElement("div");
-    bar.className = "bar";
-    bar.style.height = `${(Number(item.marketValue) / maxValue) * 100}%`;
-
-    const label = document.createElement("span");
-    label.textContent = item.year;
-
-    group.appendChild(bar);
-    group.appendChild(label);
-    trendContainer.appendChild(group);
-  });
-}
-
 function renderSummary(property) {
-  document.getElementById("opaIdText").textContent = property.propertyId;
-  document.getElementById("addressText").textContent = property.address || "N/A";
-  document.getElementById("neighborhoodText").textContent =
-    property.neighborhood || "N/A";
-
   const latest = property.history[property.history.length - 1];
+
+  document.getElementById("opaIdText").textContent = property.propertyId;
+  document.getElementById("addressText").textContent = property.address;
   document.getElementById("currentValueText").textContent = formatMoney(
     latest.marketValue,
   );
   document.getElementById("taxYearText").textContent = latest.year;
+  document.getElementById("neighborhoodText").textContent = property.neighborhood;
+}
+
+function renderAssessmentHistory(property) {
+  const chartElement = document.getElementById("assessmentHistoryChart");
+
+  if (assessmentHistoryChart) {
+    assessmentHistoryChart.destroy();
+  }
+
+  assessmentHistoryChart = new window.ApexCharts(chartElement, {
+    chart: {
+      type: "bar",
+      height: 300,
+      width: "100%",
+      parentHeightOffset: 0,
+      toolbar: {
+        show: false,
+      },
+    },
+    series: [
+      {
+        name: "Assessed value",
+        data: property.history.map((item) => Number(item.marketValue)),
+      },
+    ],
+    colors: ["#0d3b66"],
+    fill: {
+      type: "solid",
+      opacity: 1,
+    },
+    plotOptions: {
+      bar: {
+        borderRadius: 4,
+        columnWidth: "58%",
+      },
+    },
+    dataLabels: {
+      enabled: false,
+    },
+    grid: {
+      borderColor: "#e5e7eb",
+      padding: {
+        left: 10,
+        right: 12,
+        top: 6,
+        bottom: 0,
+      },
+      strokeDashArray: 4,
+    },
+    xaxis: {
+      categories: property.history.map((item) => item.year),
+      title: {
+        text: "Tax year",
+      },
+      labels: {
+        rotate: -45,
+        rotateAlways: false,
+        trim: false,
+        hideOverlappingLabels: false,
+        style: {
+          fontSize: "11px",
+        },
+      },
+    },
+    yaxis: {
+      title: {
+        text: "Assessed value",
+      },
+      labels: {
+        minWidth: 72,
+        formatter: (value) => formatCompactCurrency(value),
+      },
+    },
+    tooltip: {
+      x: {
+        formatter: (_value, { dataPointIndex }) =>
+          `Tax year ${property.history[dataPointIndex].year}`,
+      },
+      y: {
+        formatter: (value) => formatMoney(value),
+        title: {
+          formatter: () => "Assessed value:",
+        },
+      },
+    },
+    responsive: [
+      {
+        breakpoint: 760,
+        options: {
+          chart: {
+            height: 320,
+          },
+          plotOptions: {
+            bar: {
+              columnWidth: "66%",
+            },
+          },
+        },
+      },
+    ],
+  });
+
+  assessmentHistoryChart.render();
 }
 
 function renderProperty(property) {
   renderSummary(property);
-  renderTrend(property);
+  renderAssessmentHistory(property);
   updateMap(property);
 }
 
-document.addEventListener("DOMContentLoaded", () => {
-  initializeMap();
-  resetView();
+function lookupProperty() {
+  const opaId = document.getElementById("opaIdInput").value.trim();
+  const property = SAMPLE_PROPERTIES.find((item) => item.propertyId === opaId);
 
-  document.getElementById("searchBtn").addEventListener("click", () => {
-    const opaId = document.getElementById("opaIdInput").value.trim();
-    const match = data.find((item) => item.propertyId === opaId);
+  if (!property) {
+    setLookupMessage("OPA ID not found in sample data. Try 502244720.");
+    return;
+  }
 
-    if (match) {
-      renderProperty(match);
+  setLookupMessage("");
+  renderProperty(property);
+}
+
+function setChartError(message = "") {
+  const errorElement = document.getElementById("latest-assessment-chart-error");
+  errorElement.textContent = message;
+  errorElement.style.display = message ? "block" : "none";
+}
+
+function setChartHelperText(message) {
+  document.getElementById("latest-assessment-chart-helper").textContent = message;
+}
+
+function destroyLatestAssessmentChart() {
+  if (latestAssessmentChart) {
+    latestAssessmentChart.destroy();
+    latestAssessmentChart = null;
+  }
+}
+
+function buildDisplayBins(rows) {
+  const bins = [];
+  let lowerBound = 0;
+
+  while (lowerBound < MAIN_DISPLAY_MAX) {
+    bins.push({
+      lowerBound,
+      upperBound: lowerBound + MAIN_DISPLAY_BIN_SIZE,
+      propertyCount: 0,
+      label: "",
+      tooltipLabel: "",
+      isOverflow: false,
+    });
+    lowerBound += MAIN_DISPLAY_BIN_SIZE;
+  }
+
+  bins.push({
+    lowerBound: MAIN_DISPLAY_MAX,
+    upperBound: null,
+    propertyCount: 0,
+    label: OVERFLOW_LABEL,
+    tooltipLabel: `>${formatMoney(MAIN_DISPLAY_MAX)}`,
+    isOverflow: true,
+  });
+
+  for (const row of rows) {
+    if (row.lowerBound >= MAIN_DISPLAY_MAX || row.upperBound > MAIN_DISPLAY_MAX) {
+      bins[bins.length - 1].propertyCount += row.propertyCount;
+      continue;
+    }
+
+    const index = Math.floor(row.lowerBound / MAIN_DISPLAY_BIN_SIZE);
+    if (bins[index]) {
+      bins[index].propertyCount += row.propertyCount;
+    }
+  }
+
+  for (const bin of bins) {
+    if (bin.isOverflow) {
+      continue;
+    }
+
+    bin.tooltipLabel = `${formatMoney(bin.lowerBound)} ${RANGE_SEPARATOR} ${formatMoney(bin.upperBound - 1)}`;
+
+    if (bin.lowerBound === 0) {
+      bin.label = "$0";
+    } else if (bin.lowerBound % 500000 === 0) {
+      bin.label = formatCompactCurrency(bin.lowerBound);
     } else {
-      alert("OPA ID not found in sample data.");
-      resetView();
+      bin.label = "";
+    }
+  }
+
+  return bins;
+}
+
+function renderLatestAssessmentChart(rows, latestTaxYear) {
+  const chartElement = document.getElementById("latest-assessment-chart");
+  const categories = rows.map((row) => row.label);
+  const seriesData = rows.map((row) => ({
+    x: row.label,
+    y: row.propertyCount,
+  }));
+
+  destroyLatestAssessmentChart();
+  setChartError("");
+  setChartHelperText(
+    `Latest tax year (${latestTaxYear}) distribution. Main range shown up to $2.5M; higher values grouped into an overflow bin.`,
+  );
+
+  latestAssessmentChart = new window.ApexCharts(chartElement, {
+    chart: {
+      type: "bar",
+      height: 340,
+      toolbar: {
+        show: false,
+      },
+      animations: {
+        easing: "easeinout",
+        speed: 350,
+      },
+    },
+    series: [
+      {
+        name: "Properties",
+        data: seriesData,
+      },
+    ],
+    colors: ["#0d3b66"],
+    plotOptions: {
+      bar: {
+        borderRadius: 4,
+        columnWidth: "86%",
+      },
+    },
+    dataLabels: {
+      enabled: false,
+    },
+    legend: {
+      show: false,
+    },
+    grid: {
+      borderColor: "#e5e7eb",
+      strokeDashArray: 4,
+    },
+    xaxis: {
+      categories,
+      tickPlacement: "between",
+      labels: {
+        rotate: 0,
+        trim: false,
+        hideOverlappingLabels: true,
+      },
+      title: {
+        text: "Assessed value range",
+      },
+    },
+    yaxis: {
+      title: {
+        text: "Property count",
+      },
+      labels: {
+        formatter: (value) => formatNumber(Math.round(value)),
+      },
+    },
+    tooltip: {
+      x: {
+        formatter: (_value, { dataPointIndex }) => rows[dataPointIndex].tooltipLabel,
+      },
+      y: {
+        formatter: (value) => `${formatNumber(value)} properties`,
+      },
+    },
+  });
+
+  latestAssessmentChart.render();
+}
+
+async function loadLatestAssessmentChart() {
+  try {
+    setChartError("");
+    setChartHelperText("Loading citywide assessment distribution...");
+
+    if (!window.ApexCharts) {
+      throw new Error("Assessment chart library failed to load.");
+    }
+
+    const response = await fetch(TAX_YEAR_ASSESSMENT_BINS_URL);
+    if (!response.ok) {
+      throw new Error(`Unable to load assessment chart data (${response.status}).`);
+    }
+
+    const payload = await response.json();
+    if (!Array.isArray(payload) || payload.length === 0) {
+      destroyLatestAssessmentChart();
+      setChartError("No assessment distribution data is available right now.");
+      return;
+    }
+
+    const taxYears = payload
+      .map((row) => Number(row.tax_year))
+      .filter((taxYear) => Number.isFinite(taxYear));
+
+    if (taxYears.length === 0) {
+      destroyLatestAssessmentChart();
+      setChartError("Assessment distribution data is missing tax year values.");
+      return;
+    }
+
+    const latestTaxYear = Math.max(...taxYears);
+    const latestRows = payload
+      .filter((row) => Number(row.tax_year) === latestTaxYear)
+      .map((row) => ({
+        lowerBound: Number(row.lower_bound),
+        upperBound: Number(row.upper_bound),
+        propertyCount: Number(row.property_count),
+      }))
+      .filter(
+        (row) =>
+          Number.isFinite(row.lowerBound) &&
+          Number.isFinite(row.upperBound) &&
+          Number.isFinite(row.propertyCount),
+      )
+      .sort((left, right) => left.lowerBound - right.lowerBound);
+
+    if (latestRows.length === 0) {
+      destroyLatestAssessmentChart();
+      setChartError(
+        `No assessment distribution bins were found for tax year ${latestTaxYear}.`,
+      );
+      return;
+    }
+
+    renderLatestAssessmentChart(buildDisplayBins(latestRows), latestTaxYear);
+  } catch (error) {
+    destroyLatestAssessmentChart();
+    setChartError(
+      error instanceof Error
+        ? error.message
+        : "Unable to load the latest assessment distribution chart.",
+    );
+  }
+}
+
+document.addEventListener("DOMContentLoaded", () => {
+  const sampleProperty = SAMPLE_PROPERTIES[0];
+
+  initializeMap();
+  renderProperty(sampleProperty);
+  loadLatestAssessmentChart();
+
+  document.getElementById("opaIdInput").value = sampleProperty.propertyId;
+  document.getElementById("searchBtn").addEventListener("click", lookupProperty);
+  document.getElementById("opaIdInput").addEventListener("keydown", (event) => {
+    if (event.key === "Enter") {
+      lookupProperty();
     }
   });
 });

--- a/ui/widget/style.css
+++ b/ui/widget/style.css
@@ -246,6 +246,36 @@ body {
   line-height: 1.45;
 }
 
+.context-row {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 2px 12px;
+  padding: 8px 0;
+  border-top: 1px solid var(--border-soft);
+}
+
+.context-row:first-of-type {
+  border-top: none;
+}
+
+.context-label,
+.context-helper {
+  color: var(--muted);
+  font-size: 0.88rem;
+  line-height: 1.35;
+}
+
+.context-value {
+  color: var(--heading);
+  font-size: 1.25rem;
+  font-variant-numeric: tabular-nums;
+  line-height: 1;
+}
+
+.context-helper {
+  grid-column: 1 / -1;
+}
+
 .card-header {
   margin-bottom: 12px;
 }

--- a/ui/widget/style.css
+++ b/ui/widget/style.css
@@ -3,15 +3,18 @@
 }
 
 :root {
-  --bg: #f0f0f0;
+  --bg: #f0f2f5;
   --surface: #fff;
-  --border: #d9d9d9;
-  --text: #222;
-  --muted: #5c5c5c;
-  --heading: #0f0f0f;
+  --border: #d9dde5;
+  --text: #20242c;
+  --muted: #626b7a;
+  --heading: #111827;
   --accent: #0d3b66;
-  --accent-hover: #0a2f52;
-  --soft: #f7f7f7;
+  --accent-hover: #092f52;
+  --soft: #f7f8fa;
+  --error-bg: #fef2f2;
+  --error-border: #f1c7c7;
+  --error-text: #991b1b;
 }
 
 body {
@@ -22,7 +25,7 @@ body {
 }
 
 .widget-page {
-  max-width: 1200px;
+  max-width: 1280px;
   margin: 0 auto;
   padding: 24px;
 }
@@ -36,20 +39,20 @@ body {
   color: var(--accent);
   font-size: 0.95rem;
   font-weight: 700;
-  text-transform: uppercase;
   letter-spacing: 0.04em;
+  text-transform: uppercase;
 }
 
 .widget-header h1 {
   margin: 0 0 8px;
-  font-size: 2rem;
-  line-height: 1.15;
   color: var(--heading);
+  font-size: 2.2rem;
+  line-height: 1.15;
 }
 
 .intro {
+  max-width: 780px;
   margin: 0;
-  max-width: 700px;
   color: var(--muted);
   line-height: 1.5;
 }
@@ -58,12 +61,13 @@ body {
 .card {
   background: var(--surface);
   border: 1px solid var(--border);
-  border-radius: 6px;
+  border-radius: 14px;
+  box-shadow: 0 8px 24px rgb(15 23 42 / 6%);
 }
 
 .lookup-panel {
-  padding: 18px;
   margin-bottom: 20px;
+  padding: 18px;
 }
 
 .input-label {
@@ -74,60 +78,67 @@ body {
 
 .lookup-row {
   display: grid;
-  grid-template-columns: 1fr 180px;
+  grid-template-columns: 1fr 190px;
   gap: 12px;
 }
 
 .lookup-row input {
   width: 100%;
   padding: 12px 14px;
-  border: 1px solid #bfbfbf;
-  border-radius: 4px;
-  font-size: 1rem;
+  border: 1px solid #bfc7d3;
+  border-radius: 8px;
   background: #fff;
+  font-size: 1rem;
 }
 
 .lookup-row input:focus {
-  outline: 2px solid #a3c9f1;
-  outline-offset: 1px;
   border-color: var(--accent);
+  outline: 3px solid rgb(13 59 102 / 18%);
 }
 
 .lookup-row button {
+  padding: 12px 16px;
   border: none;
-  border-radius: 4px;
+  border-radius: 8px;
   background: var(--accent);
   color: #fff;
+  cursor: pointer;
   font-size: 1rem;
   font-weight: 700;
-  cursor: pointer;
-  padding: 12px 16px;
 }
 
 .lookup-row button:hover {
   background: var(--accent-hover);
 }
 
-.helper-text {
+.helper-text,
+.lookup-message {
   margin: 8px 0 0;
   color: var(--muted);
   font-size: 0.92rem;
 }
 
-.content-grid {
+.lookup-message:not(:empty) {
+  color: var(--error-text);
+  font-weight: 700;
+}
+
+.main-grid {
   display: grid;
-  grid-template-columns: 360px 1fr;
+  grid-template-columns: minmax(300px, 380px) 1fr;
   gap: 20px;
   margin-bottom: 20px;
 }
 
 .bottom-grid {
   display: grid;
-  grid-template-columns: 1.35fr 1fr;
+  grid-template-columns: minmax(0, 0.95fr) minmax(0, 1.4fr);
   gap: 20px;
+  margin-bottom: 20px;
 }
 
 .card {
+  min-width: 0;
   padding: 20px;
 }
 
@@ -137,8 +148,8 @@ body {
 
 .card h2 {
   margin: 0 0 6px;
-  font-size: 1.35rem;
   color: var(--heading);
+  font-size: 1.35rem;
 }
 
 .card-header p {
@@ -156,7 +167,7 @@ body {
   grid-template-columns: 140px 1fr;
   gap: 16px;
   padding: 12px 0;
-  border-bottom: 1px solid #ececec;
+  border-bottom: 1px solid #eceff3;
 }
 
 .summary-row:first-child {
@@ -175,72 +186,71 @@ body {
 
 .summary-row dd {
   margin: 0;
-  font-weight: 700;
   color: var(--text);
+  font-weight: 700;
   text-align: right;
 }
 
-
 #map {
   height: 400px;
-  border: 1px solid #d9d9d9;
-  border-radius: 4px;
   overflow: hidden;
-  background: #f7f7f7;
-}
-
-.empty-message {
-  min-height: 220px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  color: #666;
-  font-weight: 600;
-  text-align: center;
-}
-
-.trend-placeholder {
-  height: 280px;
-  padding: 18px 12px 32px;
-  border: 1px dashed #bfbfbf;
-  border-radius: 4px;
+  border: 1px solid #d9dde5;
+  border-radius: 10px;
   background: var(--soft);
-  display: flex;
-  align-items: flex-end;
-  gap: 14px;
 }
 
-.bar-group {
-  flex: 1;
-  height: 100%;
-  display: flex;
-  flex-direction: column;
-  justify-content: flex-end;
-  align-items: center;
-  gap: 8px;
+.history-card,
+.distribution-card {
+  min-width: 0;
+  overflow: hidden;
 }
 
-.bar {
+.history-chart {
   width: 100%;
-  max-width: 54px;
-  background: linear-gradient(180deg, #7aa6d1 0%, #0d3b66 100%);
-  border-radius: 4px 4px 0 0;
-  min-height: 24px;
+  min-height: 320px;
+  overflow: hidden;
 }
 
-.bar-group span {
-  font-size: 0.88rem;
-  color: var(--muted);
+.history-chart .apexcharts-canvas,
+#latest-assessment-chart .apexcharts-canvas {
+  max-width: 100%;
+}
+
+#latest-assessment-chart {
+  min-height: 340px;
+  padding: 8px 4px 0;
+}
+
+.chart-error {
+  display: none;
+  margin-bottom: 12px;
+  padding: 12px 14px;
+  border: 1px solid var(--error-border);
+  border-radius: 10px;
+  background: var(--error-bg);
+  color: var(--error-text);
+  font-size: 0.95rem;
+  line-height: 1.5;
+}
+
+.notes-card {
+  margin-bottom: 8px;
 }
 
 .notes-text {
   margin: 0;
   color: var(--text);
-  line-height: 1.6;
+  line-height: 1.65;
 }
 
-@media (width <= 900px) {
-  .content-grid,
+.notes-text code {
+  padding: 2px 5px;
+  border-radius: 4px;
+  background: #eef2f7;
+}
+
+@media (width <= 980px) {
+  .main-grid,
   .bottom-grid {
     grid-template-columns: 1fr;
   }
@@ -256,5 +266,13 @@ body {
 
   .summary-row dd {
     text-align: left;
+  }
+
+  #map {
+    height: 320px;
+  }
+
+  #latest-assessment-chart {
+    min-height: 300px;
   }
 }

--- a/ui/widget/style.css
+++ b/ui/widget/style.css
@@ -214,6 +214,16 @@ body {
   line-height: 1.45;
 }
 
+.context-card {
+  background: #fbfcfd;
+}
+
+.context-text {
+  margin: 8px 0 0;
+  color: var(--text);
+  line-height: 1.45;
+}
+
 .card-header {
   margin-bottom: 12px;
 }

--- a/ui/widget/style.css
+++ b/ui/widget/style.css
@@ -15,6 +15,8 @@
   --accent-dark: #164a78;
   --success: #1f7a4d;
   --error: #9f1d24;
+  --increase: #8a5a22;
+  --decrease: #1f5f99;
 }
 
 body {
@@ -140,11 +142,11 @@ body {
 .lookup-message {
   margin-top: 8px;
   font-size: 0.92rem;
-  font-weight: 700;
+  font-weight: 500;
 }
 
 .lookup-message[data-type="success"] {
-  color: var(--success);
+  color: var(--muted);
 }
 
 .lookup-message[data-type="error"] {
@@ -197,6 +199,7 @@ body {
 
 .official-card {
   border-color: #9ab9d8;
+  border-left: 6px solid var(--accent);
   background: #f8fbff;
 }
 
@@ -211,16 +214,35 @@ body {
 .change-text {
   margin: 12px 0 0;
   color: var(--text);
+  font-weight: 700;
   line-height: 1.45;
 }
 
+.change-positive {
+  color: var(--increase);
+}
+
+.change-negative {
+  color: var(--decrease);
+}
+
+.change-neutral {
+  color: var(--muted);
+}
+
 .context-card {
+  border-color: var(--border-soft);
   background: #fbfcfd;
+  padding: 14px 16px;
+}
+
+.context-card h2 {
+  font-size: 1rem;
 }
 
 .context-text {
-  margin: 8px 0 0;
-  color: var(--text);
+  margin: 6px 0 0;
+  color: var(--muted);
   line-height: 1.45;
 }
 

--- a/ui/widget/style.css
+++ b/ui/widget/style.css
@@ -3,276 +3,272 @@
 }
 
 :root {
-  --bg: #f0f2f5;
-  --surface: #fff;
-  --border: #d9dde5;
-  --text: #20242c;
-  --muted: #626b7a;
-  --heading: #111827;
-  --accent: #0d3b66;
-  --accent-hover: #092f52;
-  --soft: #f7f8fa;
-  --error-bg: #fef2f2;
-  --error-border: #f1c7c7;
-  --error-text: #991b1b;
+  --bg: #eef1f5;
+  --surface: #ffffff;
+  --surface-soft: #f7f9fb;
+  --border: #cfd6df;
+  --border-soft: #e3e7ed;
+  --text: #1d2733;
+  --muted: #5d6875;
+  --heading: #0f2438;
+  --accent: #1f5f99;
+  --accent-dark: #164a78;
+  --success: #1f7a4d;
+  --error: #9f1d24;
 }
 
 body {
   margin: 0;
-  font-family: Arial, Helvetica, sans-serif;
   background: var(--bg);
   color: var(--text);
+  font-family: Arial, Helvetica, sans-serif;
 }
 
-.widget-page {
-  max-width: 1280px;
+.widget-shell {
+  width: min(100%, 620px);
   margin: 0 auto;
-  padding: 24px;
+  padding: 20px;
 }
 
 .widget-header {
-  margin-bottom: 24px;
+  margin-bottom: 16px;
 }
 
-.eyebrow {
-  margin: 0 0 8px;
+.eyebrow,
+.section-label {
+  margin: 0 0 6px;
   color: var(--accent);
-  font-size: 0.95rem;
+  font-size: 0.78rem;
   font-weight: 700;
-  letter-spacing: 0.04em;
+  letter-spacing: 0.06em;
   text-transform: uppercase;
 }
 
 .widget-header h1 {
   margin: 0 0 8px;
   color: var(--heading);
-  font-size: 2.2rem;
+  font-size: 1.75rem;
   line-height: 1.15;
 }
 
-.intro {
-  max-width: 780px;
-  margin: 0;
+.intro,
+.helper-text,
+.subtle-text,
+.estimate-note,
+.source-note,
+.card-header p {
   color: var(--muted);
   line-height: 1.5;
 }
 
-.lookup-panel,
-.card {
-  background: var(--surface);
-  border: 1px solid var(--border);
-  border-radius: 14px;
-  box-shadow: 0 8px 24px rgb(15 23 42 / 6%);
+.intro,
+.helper-text,
+.lookup-message,
+.card-header p,
+.estimate-note,
+.source-note p {
+  margin: 0;
 }
 
-.lookup-panel {
-  margin-bottom: 20px;
+.card,
+.lookup-card {
+  margin-bottom: 12px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--surface);
+}
+
+.card {
   padding: 18px;
 }
 
-.input-label {
+.lookup-card {
+  padding: 16px;
+}
+
+.lookup-card label {
   display: block;
   margin-bottom: 8px;
+  color: var(--heading);
   font-weight: 700;
 }
 
 .lookup-row {
   display: grid;
-  grid-template-columns: 1fr 190px;
-  gap: 12px;
+  grid-template-columns: 1fr auto;
+  gap: 8px;
+}
+
+.lookup-row input,
+.lookup-row button {
+  min-height: 42px;
+  border-radius: 6px;
+  font-size: 1rem;
 }
 
 .lookup-row input {
   width: 100%;
-  padding: 12px 14px;
-  border: 1px solid #bfc7d3;
-  border-radius: 8px;
-  background: #fff;
-  font-size: 1rem;
+  border: 1px solid #b8c2cf;
+  padding: 10px 12px;
 }
 
 .lookup-row input:focus {
   border-color: var(--accent);
-  outline: 3px solid rgb(13 59 102 / 18%);
+  outline: 3px solid rgb(31 95 153 / 18%);
 }
 
 .lookup-row button {
-  padding: 12px 16px;
-  border: none;
-  border-radius: 8px;
+  border: 1px solid var(--accent-dark);
+  padding: 10px 14px;
   background: var(--accent);
-  color: #fff;
+  color: #ffffff;
   cursor: pointer;
-  font-size: 1rem;
   font-weight: 700;
 }
 
-.lookup-row button:hover {
-  background: var(--accent-hover);
+.lookup-row button:disabled {
+  border-color: #9aa6b3;
+  background: #9aa6b3;
+  cursor: wait;
 }
 
-.helper-text,
+.helper-text {
+  margin-top: 8px;
+  font-size: 0.9rem;
+}
+
 .lookup-message {
-  margin: 8px 0 0;
-  color: var(--muted);
+  margin-top: 8px;
   font-size: 0.92rem;
-}
-
-.lookup-message:not(:empty) {
-  color: var(--error-text);
   font-weight: 700;
 }
 
-.main-grid {
-  display: grid;
-  grid-template-columns: minmax(300px, 380px) 1fr;
-  gap: 20px;
-  margin-bottom: 20px;
+.lookup-message[data-type="success"] {
+  color: var(--success);
 }
 
-.bottom-grid {
-  display: grid;
-  grid-template-columns: minmax(0, 0.95fr) minmax(0, 1.4fr);
-  gap: 20px;
-  margin-bottom: 20px;
+.lookup-message[data-type="error"] {
+  color: var(--error);
 }
 
-.card {
-  min-width: 0;
-  padding: 20px;
+.empty-state {
+  background: var(--surface-soft);
 }
 
-.card-header {
-  margin-bottom: 14px;
-}
-
+.empty-state h2,
 .card h2 {
-  margin: 0 0 6px;
+  margin: 0 0 8px;
   color: var(--heading);
+  font-size: 1.2rem;
+}
+
+.empty-state p {
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.55;
+}
+
+.property-card h2 {
   font-size: 1.35rem;
 }
 
-.card-header p {
-  margin: 0;
-  color: var(--muted);
-  line-height: 1.4;
+.property-details {
+  margin: 12px 0 0;
 }
 
-.summary-list {
-  margin: 0;
-}
-
-.summary-row {
-  display: grid;
-  grid-template-columns: 140px 1fr;
+.property-details div {
+  display: flex;
+  justify-content: space-between;
   gap: 16px;
-  padding: 12px 0;
-  border-bottom: 1px solid #eceff3;
+  padding: 9px 0;
+  border-top: 1px solid var(--border-soft);
 }
 
-.summary-row:first-child {
-  padding-top: 4px;
-}
-
-.summary-row:last-child {
-  border-bottom: none;
-  padding-bottom: 0;
-}
-
-.summary-row dt {
-  margin: 0;
+.property-details dt {
   color: var(--muted);
 }
 
-.summary-row dd {
+.property-details dd {
   margin: 0;
   color: var(--text);
   font-weight: 700;
   text-align: right;
 }
 
-#map {
-  height: 400px;
-  overflow: hidden;
-  border: 1px solid #d9dde5;
-  border-radius: 10px;
-  background: var(--soft);
+.official-card {
+  border-color: #9ab9d8;
+  background: #f8fbff;
 }
 
-.history-card,
-.distribution-card {
-  min-width: 0;
+.official-value {
+  margin: 10px 0 4px;
+  color: var(--heading);
+  font-size: 2.15rem;
+  font-weight: 800;
+  line-height: 1;
+}
+
+.change-text {
+  margin: 12px 0 0;
+  color: var(--text);
+  line-height: 1.45;
+}
+
+.card-header {
+  margin-bottom: 12px;
+}
+
+.history-card {
   overflow: hidden;
 }
 
 .history-chart {
   width: 100%;
-  min-height: 320px;
+  min-height: 300px;
   overflow: hidden;
 }
 
-.history-chart .apexcharts-canvas,
-#latest-assessment-chart .apexcharts-canvas {
+.history-chart .apexcharts-canvas {
   max-width: 100%;
 }
 
-#latest-assessment-chart {
-  min-height: 340px;
-  padding: 8px 4px 0;
+.estimate-card {
+  background: var(--surface-soft);
 }
 
-.chart-error {
-  display: none;
-  margin-bottom: 12px;
-  padding: 12px 14px;
-  border: 1px solid var(--error-border);
-  border-radius: 10px;
-  background: var(--error-bg);
-  color: var(--error-text);
-  font-size: 0.95rem;
-  line-height: 1.5;
+.estimate-value {
+  margin: 10px 0 6px;
+  color: var(--heading);
+  font-size: 1.55rem;
+  font-weight: 800;
 }
 
-.notes-card {
-  margin-bottom: 8px;
+.estimate-note {
+  margin-top: 12px;
+  padding-top: 12px;
+  border-top: 1px solid var(--border-soft);
+  font-size: 0.92rem;
 }
 
-.notes-text {
-  margin: 0;
-  color: var(--text);
-  line-height: 1.65;
+.source-note {
+  padding: 0 2px 8px;
+  font-size: 0.86rem;
 }
 
-.notes-text code {
-  padding: 2px 5px;
-  border-radius: 4px;
-  background: #eef2f7;
+[hidden] {
+  display: none !important;
 }
 
-@media (width <= 980px) {
-  .main-grid,
-  .bottom-grid {
-    grid-template-columns: 1fr;
+@media (width <= 520px) {
+  .widget-shell {
+    padding: 14px;
   }
 
   .lookup-row {
     grid-template-columns: 1fr;
   }
 
-  .summary-row {
-    grid-template-columns: 1fr;
-    gap: 6px;
-  }
-
-  .summary-row dd {
-    text-align: left;
-  }
-
-  #map {
-    height: 320px;
-  }
-
-  #latest-assessment-chart {
-    min-height: 300px;
+  .official-value {
+    font-size: 1.85rem;
   }
 }


### PR DESCRIPTION
## Summary

This PR adds ZIP-code context and real property lookup support to the frontend serving layer.

The main goal is to make the reviewer dashboard and owner-facing widget more useful without changing the core data pipeline architecture:

- Reviewer dashboard continues to use public Cloud Storage assets and vector tiles.
- Owner widget uses a BigQuery-backed lookup API for single-property details.
- Browser code does not query BigQuery directly.
- ZIP code is used as the only area geography for this version.

## What changed

### New ZIP context export

Added a new Cloud Function task:

- `tasks/export_zip_assessment_context/`

This exports:

- `gs://musa5090s26-team1-public/configs/zip_assessment_context.json`

The JSON provides ZIP-level context, including:

- ZIP record counts
- approximate official assessment medians
- approximate model estimate medians
- official/model value bins
- gap summary context

### Property tile fields

Updated `export-property-tile-info` so property tile features include additional fields needed by the reviewer UI:

- `zip_code`
- `gap_value`
- `gap_pct`
- `tax_year_assessed_value`
- `current_assessed_value`

This supports ZIP filtering, gap display, and selected-property comparison in the reviewer dashboard.

### Property lookup API

Updated `tasks/property-assessment-lookup/` so the lookup API returns:

- property information
- official assessment history
- latest official assessed value
- model estimate
- gap metrics
- citywide and ZIP percentile context

This keeps owner/property lookup dynamic while avoiding direct BigQuery queries from the browser.

### Reviewer dashboard

Updated `ui/reviewer/` to support:

- Citywide / ZIP selector
- ZIP-aware summary stats
- ZIP official/model distribution charts
- selected-property percentile context
- selected-property assessment history mini chart via lookup API
- 7-class value styling
- symmetric fixed gap bins
- cleaner tooltip behavior

The reviewer dashboard still uses public GCS configs and vector tiles as its primary data source.

### Owner widget

Updated `ui/widget/` to support:

- real property lookup through the lookup API
- official assessed value as the primary value
- assessment history as a line chart
- estimated current market value as secondary/informational context
- compact citywide/ZIP percentile context
- clearer source/disclaimer copy

The widget no longer depends on hard-coded sample property data.

### Workflow and deploy docs

Updated:

- `tasks/data-pipeline/workflow.yaml`
- `tasks/data-pipeline/DEPLOY.md`

to include the new ZIP context export step.

## Validation

The following checks passed:

```bash
python -m py_compile tasks/property-assessment-lookup/main.py
python -m py_compile tasks/export_zip_assessment_context/main.py
node --check ui/reviewer/main.js
node --check ui/widget/main.js