### PR TITLE
Fix prediction model feature contract

### DIFF
--- a/tasks/predict-current-assessments/README.md
+++ b/tasks/predict-current-assessments/README.md
@@ -1,0 +1,28 @@
+# Predict Current Assessments
+
+This Cloud Run job trains the current assessment model and writes prediction
+output for downstream exports.
+
+## Table Semantics
+
+- `core.opa_assessments` stores official historical assessment records.
+- `derived.current_assessments` stores model-generated prediction output, not
+  official assessment records.
+- `derived.current_assessments.predicted_value` is the model estimate consumed
+  by downstream frontend exports and lookup APIs.
+
+## Model Contract
+
+The model predicts `log_sale_price` using these features:
+
+- `total_livable_area`
+- `taxable_building`
+- `taxable_land`
+- `quality_grade`
+- `interior_condition_rev`
+- `exterior_condition_rev`
+- `garage_spaces`
+- `year_built_int`
+
+The `assessment_year` field is intentionally excluded from the model feature
+set because it was null for all prediction rows.

--- a/tasks/predict-current-assessments/sql/build_prediction_input.sql
+++ b/tasks/predict-current-assessments/sql/build_prediction_input.sql
@@ -6,7 +6,6 @@ SELECT
     SAFE_CAST(taxable_land AS FLOAT64) AS taxable_land,
     quality_grade,
     SAFE_CAST(garage_spaces AS FLOAT64) AS garage_spaces,
-    EXTRACT(YEAR FROM SAFE.PARSE_DATE('%Y-%m-%d', assessment_date)) AS assessment_year,
     SAFE_CAST(year_built AS INT64) AS year_built_int,
     CASE
         WHEN SAFE_CAST(interior_condition AS INT64) IS NOT NULL

--- a/tasks/predict-current-assessments/sql/predict_current_assessments.sql
+++ b/tasks/predict-current-assessments/sql/predict_current_assessments.sql
@@ -15,7 +15,6 @@ FROM ML.predict (
             interior_condition_rev,
             exterior_condition_rev,
             garage_spaces,
-            assessment_year,
             year_built_int
         FROM `musa5090s26-team1.derived.current_assessments_prediction_input`
     )

--- a/tasks/predict-current-assessments/sql/train_model.sql
+++ b/tasks/predict-current-assessments/sql/train_model.sql
@@ -20,10 +20,15 @@ SELECT
         ELSE NULL
     END AS exterior_condition_rev,
     SAFE_CAST(garage_spaces AS FLOAT64) AS garage_spaces,
-    SAFE_CAST(assessment_year AS INT64) AS assessment_year,
     SAFE_CAST(year_built AS INT64) AS year_built_int
 FROM `musa5090s26-team1.derived.current_assessments_model_training_data`
 WHERE
     SAFE_CAST(target_sale_price AS FLOAT64) IS NOT NULL
     AND SAFE_CAST(target_sale_price AS FLOAT64) > 1000
     AND SAFE_CAST(target_sale_price AS FLOAT64) < 5000000
+    AND EXTRACT(YEAR FROM SAFE_CAST(sale_date AS TIMESTAMP)) >= 2020
+    AND SAFE_CAST(total_livable_area AS FLOAT64) IS NOT NULL
+    AND SAFE_CAST(total_livable_area AS FLOAT64) > 0
+    AND SAFE_CAST(taxable_building AS FLOAT64) IS NOT NULL
+    AND SAFE_CAST(taxable_land AS FLOAT64) IS NOT NULL
+    AND SAFE_CAST(year_built AS INT64) IS NOT NULL


### PR DESCRIPTION
## Summary

This PR fixes the prediction model feature contract after diagnostics showed that model predictions were systematically too low.

Main changes:
- Remove `assessment_year` from the model feature set because it was null for all rows in `current_assessments_prediction_input`.
- Train the model only on recent sales (`sale_year >= 2020`) to avoid older sale prices pulling predictions downward.
- Clarify that `derived.current_assessments` stores model prediction output, while `core.opa_assessments` stores official historical assessments.

Table names and downstream output fields are unchanged for compatibility.

## Validation

- Redeployed and ran `predict-current-assessments`
- Confirmed `assessment_year` is no longer a model feature
- Confirmed prediction input schema matches the model feature set
- Compared latest official median vs predicted median before/after